### PR TITLE
5 add driver support for minas a6 servo and ep2339

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,15 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,7 +572,6 @@ name = "ethercat_hal"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "approx",
  "bitvec",
  "ethercat_hal_derive",
  "ethercrab",
@@ -590,6 +580,7 @@ dependencies = [
  "ta",
  "tokio",
  "tracing",
+ "triple_buffer",
  "units",
 ]
 
@@ -959,15 +950,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +963,10 @@ checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "machines"
+version = "0.1.0"
 
 [[package]]
 name = "memchr"
@@ -1104,29 +1090,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "pcap"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,8 +1208,10 @@ dependencies = [
  "bitvec",
  "ethercat_hal",
  "ethercat_hal_derive",
+ "machines",
  "modbus",
  "tokio",
+ "units",
 ]
 
 [[package]]
@@ -1297,15 +1262,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1632,9 +1588,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -1743,6 +1697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "triple_buffer"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e875ab7068a75b74f419da453927e05527c36f0001b3c7aad3ce443640683487"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -1,6 +1,7 @@
 use crate::{
     ChannelRequest, ChannelRequests, ChannelResponse, ETHERCAT_TX_RX_SIZE, EtherCATState,
     MAX_SUBDEVICES, MetaSubdevice, PDI_LEN, PDU_STORAGE, SdoType,
+    devices::panasonic_modules::minas_a6::{EncoderResolution, MinasA6BMotor},
     ethercat_helpers::{sdo_read, sdo_write},
     get_async_runtime,
     machine_ident_read::{MachineDeviceInfo, read_device_identifications},
@@ -21,7 +22,11 @@ use ta::{Next, indicators::ExponentialMovingAverage};
 use tokio::time::interval;
 use triple_buffer::{Input, Output};
 
-pub struct EtherCATController<C,P> where C : Consumer, P: Producer {
+pub struct EtherCATController<C, P>
+where
+    C: Consumer,
+    P: Producer,
+{
     pub cycle_time_us: u64,
     pub interface: Option<String>,
     pub machine_device_infos: Option<Vec<MachineDeviceInfo>>,
@@ -37,7 +42,11 @@ pub struct EtherCATController<C,P> where C : Consumer, P: Producer {
     output_consumer: C,
 }
 
-impl<C,P> EtherCATController<C,P> where C : Consumer, P : Producer {
+impl<C, P> EtherCATController<C, P>
+where
+    C: Consumer,
+    P: Producer,
+{
     pub fn new(
         input: P,
         output: C,
@@ -63,7 +72,6 @@ impl<C,P> EtherCATController<C,P> where C : Consumer, P : Producer {
     }
 }
 
-
 pub trait Consumer {
     fn read(&mut self) -> &[u8];
 }
@@ -74,11 +82,11 @@ pub trait Producer {
 }
 
 pub struct MockConsumer {
-    pub(crate) buffer : [u8;ETHERCAT_TX_RX_SIZE]
+    pub(crate) buffer: [u8; ETHERCAT_TX_RX_SIZE],
 }
 
 pub struct MockProducer {
-    pub(crate) buffer : [u8;ETHERCAT_TX_RX_SIZE]
+    pub(crate) buffer: [u8; ETHERCAT_TX_RX_SIZE],
 }
 
 impl Producer for MockProducer {
@@ -98,11 +106,11 @@ impl Consumer for MockConsumer {
 }
 
 pub struct TripleBufConsumer {
-    pub input_consumer: Output<[u8;ETHERCAT_TX_RX_SIZE]>,
+    pub input_consumer: Output<[u8; ETHERCAT_TX_RX_SIZE]>,
 }
 
 pub struct TripleBufProducer {
-    pub output_producer: Input<[u8;ETHERCAT_TX_RX_SIZE]>,
+    pub output_producer: Input<[u8; ETHERCAT_TX_RX_SIZE]>,
 }
 
 impl Consumer for TripleBufConsumer {
@@ -121,14 +129,20 @@ impl Producer for TripleBufProducer {
     }
 }
 
-
-
-pub struct EtherCATAppHandle<C,P> where C : Consumer, P : Producer {
+pub struct EtherCATAppHandle<C, P>
+where
+    C: Consumer,
+    P: Producer,
+{
     pub input_consumer: C,
     pub output_producer: P,
 }
 
-impl<C, P> EtherCATAppHandle<C, P> where C: Consumer, P: Producer {
+impl<C, P> EtherCATAppHandle<C, P>
+where
+    C: Consumer,
+    P: Producer,
+{
     pub fn get_inputs(&mut self) -> &[u8] {
         self.input_consumer.read()
     }
@@ -157,9 +171,9 @@ pub fn enable_dc_sync(
     });
 }
 
-unsafe impl Sync for EtherCATController<TripleBufConsumer,TripleBufProducer> {}
+unsafe impl Sync for EtherCATController<TripleBufConsumer, TripleBufProducer> {}
 
-impl EtherCATController<TripleBufConsumer,TripleBufProducer> {
+impl EtherCATController<TripleBufConsumer, TripleBufProducer> {
     pub fn ethercat_state_machine(&mut self) {
         let mut ethercat_tx_rx_handle: Result<JoinHandle<()>, std::io::Error>;
         let mut group: Option<SubDeviceGroup<MAX_SUBDEVICES, PDI_LEN>> = None;
@@ -269,13 +283,10 @@ impl EtherCATController<TripleBufConsumer,TripleBufProducer> {
                     self.subdevice_count = i;
                     let msg = match self.rx_channel.try_recv() {
                         Ok(value) => value,
-                        Err(e) => {                            
-                            continue
-                        },
+                        Err(e) => continue,
                     };
 
-                    println!("GOT A MESSAGE: {:?}",msg.channel_request);
-
+                    println!("GOT A MESSAGE: {:?}", msg.channel_request);
 
                     match msg.channel_request {
                         ChannelRequests::ChangeState(ether_catstate) => match ether_catstate {
@@ -353,6 +364,36 @@ impl EtherCATController<TripleBufConsumer,TripleBufProducer> {
                             send_response(
                                 msg.response_channel,
                                 ChannelResponse::MachineDeviceInfoResponse(res),
+                            );
+                            continue;
+                        }
+                        ChannelRequests::ConfigureMinasA6B {
+                            device_address,
+                            homing_config,
+                        } => {
+                            let rt = get_async_runtime();
+                            let result: Result<EncoderResolution, anyhow::Error> =
+                                rt.block_on(async {
+                                    for subdevice in preop_group.iter(maindev) {
+                                        if subdevice.configured_address() == device_address {
+                                            let mut temp_motor = MinasA6BMotor::default();
+                                            temp_motor.homing_config = homing_config.clone();
+                                            temp_motor.configure(&subdevice).await?;
+                                            let enc = temp_motor
+                                                .read_encoder_resolution(&subdevice)
+                                                .await?;
+                                            temp_motor.setup_homing(&subdevice).await?;
+                                            return Ok(enc);
+                                        }
+                                    }
+                                    Err(anyhow::anyhow!(
+                                        "ConfigureMinasA6B: no subdevice found at address {:#06x}",
+                                        device_address
+                                    ))
+                                });
+                            send_response(
+                                msg.response_channel,
+                                ChannelResponse::ConfigureMinasA6BResponse(result),
                             );
                             continue;
                         }

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -1,7 +1,7 @@
 use crate::{
-    ChannelRequest, ChannelRequests, ChannelResponse, ETHERCAT_TX_RX_SIZE, EtherCATState,
-    MAX_SUBDEVICES, MetaSubdevice, PDI_LEN, PDU_STORAGE, SdoType,
-    devices::panasonic_modules::minas_a6::{EncoderResolution, MinasA6BMotor},
+    ChannelRequest, ChannelRequests, ChannelResponse, EncoderResolution, ETHERCAT_TX_RX_SIZE,
+    EtherCATState, MAX_SUBDEVICES, MetaSubdevice, PDI_LEN, PDU_STORAGE, SdoType,
+    devices::panasonic_modules::minas_a6::MinasA6BMotor,
     ethercat_helpers::{sdo_read, sdo_write},
     get_async_runtime,
     machine_ident_read::{MachineDeviceInfo, read_device_identifications},

--- a/ethercat_hal/src/devices/el2002.rs
+++ b/ethercat_hal/src/devices/el2002.rs
@@ -1,5 +1,5 @@
 use super::{EthercatDeviceProcessing, NewEthercatDevice, SubDeviceIdentityTuple};
-use crate::io::digital_output::{DigitalOutputDevice};
+use crate::io::digital_output::DigitalOutputDevice;
 use crate::pdo::{RxPdo, basic::BoolPdoObject};
 use ethercat_hal_derive::{EthercatDevice, RxPdo};
 

--- a/ethercat_hal/src/devices/el2004.rs
+++ b/ethercat_hal/src/devices/el2004.rs
@@ -1,5 +1,5 @@
 use super::{EthercatDeviceProcessing, NewEthercatDevice, SubDeviceIdentityTuple};
-use crate::io::digital_output::{DigitalOutputDevice};
+use crate::io::digital_output::DigitalOutputDevice;
 use crate::pdo::{RxPdo, basic::BoolPdoObject};
 use ethercat_hal_derive::{EthercatDevice, RxPdo};
 /// EL2004 4-channel digital output device
@@ -31,25 +31,17 @@ impl DigitalOutputDevice for EL2004 {
     fn set_output(&mut self, port: usize, value: bool) {
         let expect_text = "All channels should be Some(_)";
         match port {
-            0 => {
-                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into()
-            }
-            1 => {
-                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into()
-            }
-            2 => {
-                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into()
-            }
-            3 => {
-                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into()
-            }
+            0 => self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into(),
+            1 => self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into(),
+            2 => self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into(),
+            3 => self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into(),
             _ => (),
         }
     }
 
     fn get_port_count(&self) -> usize {
         4
-    }    
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/ethercat_hal/src/devices/el2008.rs
+++ b/ethercat_hal/src/devices/el2008.rs
@@ -1,5 +1,5 @@
 use super::{EthercatDeviceProcessing, NewEthercatDevice, SubDeviceIdentityTuple};
-use crate::io::digital_output::{DigitalOutputDevice};
+use crate::io::digital_output::DigitalOutputDevice;
 use crate::pdo::{RxPdo, basic::BoolPdoObject};
 use ethercat_hal_derive::{EthercatDevice, RxPdo};
 
@@ -33,30 +33,14 @@ impl DigitalOutputDevice for EL2008 {
     fn set_output(&mut self, port: usize, value: bool) {
         let expect_text = "All channels should be Some(_)";
         match port {
-            0 => {
-                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into()
-            }
-            1 => {
-                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into()
-            }
-            2 => {
-                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into()
-            }
-            3 => {
-                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into()
-            }
-            4 => {
-                self.rxpdo.channel5.as_mut().expect(expect_text).value = value.into()
-            }
-            5 => {
-                self.rxpdo.channel6.as_mut().expect(expect_text).value = value.into()
-            }
-            6 => {
-                self.rxpdo.channel7.as_mut().expect(expect_text).value = value.into()
-            }
-            7 => {
-                self.rxpdo.channel8.as_mut().expect(expect_text).value = value.into()
-            }
+            0 => self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into(),
+            1 => self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into(),
+            2 => self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into(),
+            3 => self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into(),
+            4 => self.rxpdo.channel5.as_mut().expect(expect_text).value = value.into(),
+            5 => self.rxpdo.channel6.as_mut().expect(expect_text).value = value.into(),
+            6 => self.rxpdo.channel7.as_mut().expect(expect_text).value = value.into(),
+            7 => self.rxpdo.channel8.as_mut().expect(expect_text).value = value.into(),
             _ => (),
         }
     }

--- a/ethercat_hal/src/devices/el2024.rs
+++ b/ethercat_hal/src/devices/el2024.rs
@@ -1,4 +1,4 @@
-use crate::io::digital_output::{DigitalOutputDevice};
+use crate::io::digital_output::DigitalOutputDevice;
 use crate::pdo::{RxPdo, basic::BoolPdoObject};
 use ethercat_hal_derive::{EthercatDevice, RxPdo};
 
@@ -34,27 +34,17 @@ impl DigitalOutputDevice for EL2024 {
     fn set_output(&mut self, port: usize, value: bool) {
         let expect_text = "All channels should be Some(_)";
         match port {
-            0 => {
-                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into()
-            }
-            1 => {
-                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into()
-            }
-            2 => {
-                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into()
-            }
-            3 => {
-                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into()
-            }
-            _=>(),
+            0 => self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into(),
+            1 => self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into(),
+            2 => self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into(),
+            3 => self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into(),
+            _ => (),
         }
     }
 
     fn get_port_count(&self) -> usize {
         4
     }
-
-
 }
 
 #[derive(Debug, Clone)]

--- a/ethercat_hal/src/devices/el2634.rs
+++ b/ethercat_hal/src/devices/el2634.rs
@@ -1,5 +1,5 @@
 use super::{EthercatDeviceProcessing, NewEthercatDevice};
-use crate::io::digital_output::{DigitalOutputDevice};
+use crate::io::digital_output::DigitalOutputDevice;
 use crate::pdo::{RxPdo, basic::BoolPdoObject};
 use ethercat_hal_derive::{EthercatDevice, RxPdo};
 
@@ -44,7 +44,6 @@ impl DigitalOutputDevice for EL2634 {
     fn get_port_count(&self) -> usize {
         4
     }
-
 }
 
 #[derive(Debug, Clone)]

--- a/ethercat_hal/src/devices/el2809.rs
+++ b/ethercat_hal/src/devices/el2809.rs
@@ -1,5 +1,5 @@
 use super::{EthercatDeviceProcessing, NewEthercatDevice};
-use crate::io::digital_output::{DigitalOutputDevice};
+use crate::io::digital_output::DigitalOutputDevice;
 use crate::pdo::{RxPdo, basic::BoolPdoObject};
 use ethercat_hal_derive::{EthercatDevice, RxPdo};
 
@@ -33,62 +33,29 @@ impl DigitalOutputDevice for EL2809 {
     fn set_output(&mut self, port: usize, value: bool) {
         let expect_text = "All channels should be Some(_)";
         match port {
-            0 => {
-                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into()
-            }
-            1 => {
-                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into()
-            }
-            2 => {
-                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into()
-            }
-            3 => {
-                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into()
-            }
-            4 => {
-                self.rxpdo.channel5.as_mut().expect(expect_text).value = value.into()
-            }
-            5 => {
-                self.rxpdo.channel6.as_mut().expect(expect_text).value = value.into()
-            }
-            6 => {
-                self.rxpdo.channel7.as_mut().expect(expect_text).value = value.into()
-            }
-            7 => {
-                self.rxpdo.channel8.as_mut().expect(expect_text).value = value.into()
-            }
-            8 => {
-                self.rxpdo.channel9.as_mut().expect(expect_text).value = value.into()
-            }
-            9 => {
-                self.rxpdo.channel10.as_mut().expect(expect_text).value = value.into()
-            }
-            10 => {
-                self.rxpdo.channel11.as_mut().expect(expect_text).value = value.into()
-            }
-            11 => {
-                self.rxpdo.channel12.as_mut().expect(expect_text).value = value.into()
-            }
-            12 => {
-                self.rxpdo.channel13.as_mut().expect(expect_text).value = value.into()
-            }
-            13 => {
-                self.rxpdo.channel14.as_mut().expect(expect_text).value = value.into()
-            }
-            14 => {
-                self.rxpdo.channel15.as_mut().expect(expect_text).value = value.into()
-            }
-            15 => {
-                self.rxpdo.channel16.as_mut().expect(expect_text).value = value.into()
-            }
-            _=>(),
+            0 => self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into(),
+            1 => self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into(),
+            2 => self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into(),
+            3 => self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into(),
+            4 => self.rxpdo.channel5.as_mut().expect(expect_text).value = value.into(),
+            5 => self.rxpdo.channel6.as_mut().expect(expect_text).value = value.into(),
+            6 => self.rxpdo.channel7.as_mut().expect(expect_text).value = value.into(),
+            7 => self.rxpdo.channel8.as_mut().expect(expect_text).value = value.into(),
+            8 => self.rxpdo.channel9.as_mut().expect(expect_text).value = value.into(),
+            9 => self.rxpdo.channel10.as_mut().expect(expect_text).value = value.into(),
+            10 => self.rxpdo.channel11.as_mut().expect(expect_text).value = value.into(),
+            11 => self.rxpdo.channel12.as_mut().expect(expect_text).value = value.into(),
+            12 => self.rxpdo.channel13.as_mut().expect(expect_text).value = value.into(),
+            13 => self.rxpdo.channel14.as_mut().expect(expect_text).value = value.into(),
+            14 => self.rxpdo.channel15.as_mut().expect(expect_text).value = value.into(),
+            15 => self.rxpdo.channel16.as_mut().expect(expect_text).value = value.into(),
+            _ => (),
         }
     }
 
     fn get_port_count(&self) -> usize {
         16
     }
-
 }
 
 #[derive(Debug, Clone)]

--- a/ethercat_hal/src/devices/el3001.rs
+++ b/ethercat_hal/src/devices/el3001.rs
@@ -47,7 +47,7 @@ impl NewEthercatDevice for EL3001 {
 }
 
 impl AnalogInputDevice for EL3001 {
-    fn get_input(&self, port: usize) -> Result<AnalogInputInput,anyhow::Error> {
+    fn get_input(&self, port: usize) -> Result<AnalogInputInput, anyhow::Error> {
         let raw_value = match port {
             0 => match &self.txpdo {
                 EL3001TxPdo {

--- a/ethercat_hal/src/devices/el3021.rs
+++ b/ethercat_hal/src/devices/el3021.rs
@@ -69,7 +69,7 @@ impl NewEthercatDevice for EL3021 {
 }
 
 impl AnalogInputDevice for EL3021 {
-    fn get_input(&self, port: usize) -> Result<AnalogInputInput,anyhow::Error> {
+    fn get_input(&self, port: usize) -> Result<AnalogInputInput, anyhow::Error> {
         let raw_value = match port {
             0 => match &self.txpdo {
                 EL3021TxPdo {

--- a/ethercat_hal/src/devices/el3024.rs
+++ b/ethercat_hal/src/devices/el3024.rs
@@ -78,7 +78,7 @@ impl NewEthercatDevice for EL3024 {
 }
 
 impl AnalogInputDevice for EL3024 {
-    fn get_input(&self, port: usize) -> Result<AnalogInputInput,anyhow::Error> {
+    fn get_input(&self, port: usize) -> Result<AnalogInputInput, anyhow::Error> {
         let raw_value = match port {
             0 => match &self.txpdo {
                 EL3024TxPdo {
@@ -124,7 +124,7 @@ impl AnalogInputDevice for EL3024 {
                 } => ai_compact_channel4.value,
                 _ => panic!("Invalid TxPdo assignment"),
             },
-            _ => return Err(anyhow::anyhow!("EL3024 only has 4 ports"))
+            _ => return Err(anyhow::anyhow!("EL3024 only has 4 ports")),
         };
         let raw_value = U16SigningConverter::load_raw(raw_value);
 

--- a/ethercat_hal/src/devices/el3062_0030.rs
+++ b/ethercat_hal/src/devices/el3062_0030.rs
@@ -60,7 +60,7 @@ impl NewEthercatDevice for EL3062_0030 {
 }
 
 impl AnalogInputDevice for EL3062_0030 {
-    fn get_input(&self, port: usize) -> Result<AnalogInputInput,anyhow::Error> {
+    fn get_input(&self, port: usize) -> Result<AnalogInputInput, anyhow::Error> {
         let raw_value = match port {
             0 => match &self.txpdo {
                 EL3062_0030TxPdo {

--- a/ethercat_hal/src/devices/el3204.rs
+++ b/ethercat_hal/src/devices/el3204.rs
@@ -40,7 +40,7 @@ impl TemperatureInputDevice for EL3204 {
             1 => self.txpdo.channel2.as_ref().expect(expect_text),
             2 => self.txpdo.channel3.as_ref().expect(expect_text),
             3 => self.txpdo.channel4.as_ref().expect(expect_text),
-            _ => return Err(anyhow::anyhow!("port {} does not exist on EL3204 !",port)),
+            _ => return Err(anyhow::anyhow!("port {} does not exist on EL3204 !", port)),
         };
         Ok(TemperatureInputInput {
             temperature: channel.temperature,

--- a/ethercat_hal/src/devices/el5152.rs
+++ b/ethercat_hal/src/devices/el5152.rs
@@ -106,33 +106,28 @@ impl EncoderInputDevice for EL5152 {
                 .status_channel2
                 .as_ref()
                 .map_or(0, |status| status.counter_value),
-            _ => return Err(anyhow::anyhow!("EL5152 only has two Encoder ports!!!"))
+            _ => return Err(anyhow::anyhow!("EL5152 only has two Encoder ports!!!")),
         };
         Ok(EncoderInputCounter { value })
     }
 
-    fn get_frequency(
-        &self,
-        port: usize,
-    ) -> Result<Option<EncoderInputFrequency>, anyhow::Error> {
+    fn get_frequency(&self, port: usize) -> Result<Option<EncoderInputFrequency>, anyhow::Error> {
         let frequency = match port {
-            0 => {
-                self.txpdo
-                    .frequency_channel1
-                    .as_ref()
-                    .map(|f| EncoderInputFrequency {
-                        value: f.frequency_value,
-                    })
-            }
-            1 => {
-                self.txpdo
-                    .frequency_channel2
-                    .as_ref()
-                    .map(|f| EncoderInputFrequency {
-                        value: f.frequency_value,
-                    })
-            }
-            _ => return Err(anyhow::anyhow!("EL5152 only has two Encoder ports!!!"))
+            0 => self
+                .txpdo
+                .frequency_channel1
+                .as_ref()
+                .map(|f| EncoderInputFrequency {
+                    value: f.frequency_value,
+                }),
+            1 => self
+                .txpdo
+                .frequency_channel2
+                .as_ref()
+                .map(|f| EncoderInputFrequency {
+                    value: f.frequency_value,
+                }),
+            _ => return Err(anyhow::anyhow!("EL5152 only has two Encoder ports!!!")),
         };
         Ok(frequency)
     }
@@ -152,8 +147,8 @@ impl EncoderInputDevice for EL5152 {
                 .as_ref()
                 .map(|p| EncoderInputPeriod {
                     value: p.period_value,
-                }),            
-                _ => return Err(anyhow::anyhow!("EL5152 only has two Encoder ports!!!"))
+                }),
+            _ => return Err(anyhow::anyhow!("EL5152 only has two Encoder ports!!!")),
         };
         Ok(period)
     }
@@ -172,7 +167,7 @@ impl EncoderInputDevice for EL5152 {
                     control.set_counter = true;
                 }
             }
-            _ => return Err(anyhow::anyhow!("EL5152 only has two Encoder ports!!!"))
+            _ => return Err(anyhow::anyhow!("EL5152 only has two Encoder ports!!!")),
         }
         Ok(())
     }

--- a/ethercat_hal/src/devices/el6021.rs
+++ b/ethercat_hal/src/devices/el6021.rs
@@ -523,54 +523,52 @@ impl SerialInterfaceDevice for EL6021 {
             None => return false,
         };
 
-                /*
-                Initialization was accepted
-                init_accepted 1: Initialization was completed by the terminal.
-                init_request 1: The controller requests terminal for initialization. The
-                    transmit and receive functions will be blocked, the FIFO
-                    pointer will be reset and the interface will be initialized with
-                    the values of the responsible Settings object. The execution
-                    of the initialization will be acknowledged by the terminal
-                    with the ‘Init accepted’ bit.
-                */
+        /*
+        Initialization was accepted
+        init_accepted 1: Initialization was completed by the terminal.
+        init_request 1: The controller requests terminal for initialization. The
+            transmit and receive functions will be blocked, the FIFO
+            pointer will be reset and the interface will be initialized with
+            the values of the responsible Settings object. The execution
+            of the initialization will be acknowledged by the terminal
+            with the ‘Init accepted’ bit.
+        */
         if rxpdo.control.init_request && txpdo.status.init_accepted {
             rxpdo.control.init_request = false;
             return false;
         }
 
-                /*
-                    This is the initial state
-                    init_accepted 0: Initialization was completed by the terminal.
-                    init_request 0: The terminal is ready again for serial data exchange.
-                */
-                if !rxpdo.control.init_request && !txpdo.status.init_accepted && !self.initialized {
-                    rxpdo.control.init_request = true;
-                    self.initialized = true;
-                    return false;
-                }
+        /*
+            This is the initial state
+            init_accepted 0: Initialization was completed by the terminal.
+            init_request 0: The terminal is ready again for serial data exchange.
+        */
+        if !rxpdo.control.init_request && !txpdo.status.init_accepted && !self.initialized {
+            rxpdo.control.init_request = true;
+            self.initialized = true;
+            return false;
+        }
 
-                /*
-                    init_accepted 1: Initialization was completed by the terminal.
-                    init_request 0: The terminal is ready again for serial data exchange.
-                */
-                if !rxpdo.control.init_request && txpdo.status.init_accepted {
-                    return false;
-                }
+        /*
+            init_accepted 1: Initialization was completed by the terminal.
+            init_request 0: The terminal is ready again for serial data exchange.
+        */
+        if !rxpdo.control.init_request && txpdo.status.init_accepted {
+            return false;
+        }
 
-                /*
-                    If both init_request and init_accepted == false, initialization is complete
-                    init_accepted 0: The controller once again requests the terminal to prepare for serial data exchange.
-                    init_request 0: The terminal is ready again for serial data exchange.
-                */
-                if !rxpdo.control.init_request && !txpdo.status.init_accepted && self.initialized {
-                    // set inital state of the toggle
-                    self.has_messages_last_toggle = txpdo.status.receive_request;
-                    return true;
-                }
+        /*
+            If both init_request and init_accepted == false, initialization is complete
+            init_accepted 0: The controller once again requests the terminal to prepare for serial data exchange.
+            init_request 0: The terminal is ready again for serial data exchange.
+        */
+        if !rxpdo.control.init_request && !txpdo.status.init_accepted && self.initialized {
+            // set inital state of the toggle
+            self.has_messages_last_toggle = txpdo.status.receive_request;
+            return true;
+        }
 
-                false
-            
-        
+        false
     }
 }
 

--- a/ethercat_hal/src/devices/el7031/mod.rs
+++ b/ethercat_hal/src/devices/el7031/mod.rs
@@ -2,10 +2,8 @@ pub mod coe;
 pub mod pdo;
 use crate::{
     helpers::counter_wrapper_u16_i128::CounterWrapperU16U128,
-    io::{
-        stepper_velocity_el70x1::{
-            StepperVelocityEL70x1Device, StepperVelocityEL70x1Input, StepperVelocityEL70x1Output,
-        },
+    io::stepper_velocity_el70x1::{
+        StepperVelocityEL70x1Device, StepperVelocityEL70x1Input, StepperVelocityEL70x1Output,
     },
     pdo::{PredefinedPdoAssignment, RxPdo, TxPdo},
     shared_config::el70x1::EL70x1OperationMode,
@@ -144,19 +142,16 @@ impl StepperVelocityEL70x1Device for EL7031 {
                 }
                 Ok(())
             }
-            _ =>           {
+            _ => {
                 return Err(anyhow!(
-                            "[{}::StepperVelocityEL70x1Device::stepper_velocity_state] Invalid Port",
-                            module_path!()
-                        ));
-                } 
+                    "[{}::StepperVelocityEL70x1Device::stepper_velocity_state] Invalid Port",
+                    module_path!()
+                ));
+            }
         }
     }
 
-    fn get_input(
-        &self,
-        port: usize,
-    ) -> Result<StepperVelocityEL70x1Input, anyhow::Error> {
+    fn get_input(&self, port: usize) -> Result<StepperVelocityEL70x1Input, anyhow::Error> {
         // check if operating mode is velocity
         if self.configuration.stm_features.operation_mode != EL70x1OperationMode::DirectVelocity {
             return Err(anyhow!(
@@ -185,24 +180,18 @@ impl StepperVelocityEL70x1Device for EL7031 {
             }
             _ => {
                 return Err(anyhow!(
-                            "[{}::StepperVelocityEL70x1Device::stepper_velocity_state] Invalid Port",
-                            module_path!()
-                        ));
-                } 
+                    "[{}::StepperVelocityEL70x1Device::stepper_velocity_state] Invalid Port",
+                    module_path!()
+                ));
+            }
         }
     }
 
-    fn get_speed_range(
-        &self,
-        _port: usize,
-    ) -> crate::shared_config::el70x1::EL70x1SpeedRange {
+    fn get_speed_range(&self, _port: usize) -> crate::shared_config::el70x1::EL70x1SpeedRange {
         self.configuration.stm_features.speed_range
     }
 
-    fn get_output(
-        &self,
-        port: usize,
-    ) -> Result<StepperVelocityEL70x1Output, anyhow::Error> {
+    fn get_output(&self, port: usize) -> Result<StepperVelocityEL70x1Output, anyhow::Error> {
         // check if operating mode is velocity
         if self.configuration.stm_features.operation_mode != EL70x1OperationMode::DirectVelocity {
             return Err(anyhow!(
@@ -231,12 +220,12 @@ impl StepperVelocityEL70x1Device for EL7031 {
                     set_counter: self.counter_wrapper.get_override(),
                 })
             }
-                        _ => {
+            _ => {
                 return Err(anyhow!(
-                            "[{}::StepperVelocityEL70x1Device::stepper_velocity_state] Invalid Port",
-                            module_path!()
-                        ));
-                } 
+                    "[{}::StepperVelocityEL70x1Device::stepper_velocity_state] Invalid Port",
+                    module_path!()
+                ));
+            }
         }
     }
 
@@ -279,10 +268,11 @@ impl StepperVelocityEL70x1Device for EL7031 {
         2
     }
 
-    fn get_analog_input(&self, _port: usize) -> Result<crate::io::analog_input::AnalogInputInput,anyhow::Error> {
-        Err(anyhow!(
-                   "EL7031 has no analog in ports",                    
-                ))
+    fn get_analog_input(
+        &self,
+        _port: usize,
+    ) -> Result<crate::io::analog_input::AnalogInputInput, anyhow::Error> {
+        Err(anyhow!("EL7031 has no analog in ports",))
     }
 
     fn get_analog_port_count(&self) -> usize {
@@ -293,49 +283,51 @@ impl StepperVelocityEL70x1Device for EL7031 {
         None
     }
 
-    fn is_enabled(&self,port : usize) -> bool {
+    fn is_enabled(&self, port: usize) -> bool {
         match self.get_output(port) {
             Ok(output) => output.enable,
             Err(_) => false,
         }
     }
 
-    fn get_position(&self,port : usize) -> i128 {
+    fn get_position(&self, port: usize) -> i128 {
         let input = self.get_input(port).unwrap();
         input.counter_value
     }
 
-    fn set_position(&mut self,port : usize, position: i128) {
+    fn set_position(&mut self, port: usize, position: i128) {
         let mut output = self.get_output(port).unwrap();
-        output.set_counter = Some(position);        
-        self.set_output(port,output).unwrap();
+        output.set_counter = Some(position);
+        self.set_output(port, output).unwrap();
     }
 
-    fn set_enabled(&mut self,port : usize, enabled: bool) {        
+    fn set_enabled(&mut self, port: usize, enabled: bool) {
         let mut output = self.get_output(port).unwrap();
         output.enable = enabled;
         self.set_output(port, output);
     }
 
-    fn set_speed(&mut self, port : usize, steps_per_second: f64) -> Result<(), anyhow::Error> {
+    fn set_speed(&mut self, port: usize, steps_per_second: f64) -> Result<(), anyhow::Error> {
         // Get current state to preserve other output values
         let mut output = self.get_output(port).unwrap();
 
         // Get speed range from device to convert steps to velocity
         let speed_range = self.get_speed_range(port);
-        let converter = crate::helpers::el70xx_velocity_converter::EL70x1VelocityConverter::new(&speed_range);
+        let converter =
+            crate::helpers::el70xx_velocity_converter::EL70x1VelocityConverter::new(&speed_range);
         let velocity = converter.steps_to_velocity(steps_per_second, true);
 
         output.velocity = velocity;
 
         // Write to device
-        self.set_output(port,output)
+        self.set_output(port, output)
     }
 
-    fn get_speed(&self, port : usize) -> i32 {
+    fn get_speed(&self, port: usize) -> i32 {
         let output = self.get_output(port).unwrap();
         let speed_range = self.get_speed_range(port);
-        let converter = crate::helpers::el70xx_velocity_converter::EL70x1VelocityConverter::new(&speed_range);
+        let converter =
+            crate::helpers::el70xx_velocity_converter::EL70x1VelocityConverter::new(&speed_range);
         converter.velocity_to_steps(output.velocity, true) as i32
     }
 }

--- a/ethercat_hal/src/devices/el7031_0030/mod.rs
+++ b/ethercat_hal/src/devices/el7031_0030/mod.rs
@@ -161,17 +161,14 @@ impl StepperVelocityEL70x1Device for EL7031_0030 {
             }
             _ => {
                 return Err(anyhow!(
-                            "[{}::StepperVelocityEL70x1Device::stepper_velocity_state] Invalid Port",
-                            module_path!()
-                        ));
-                } 
+                    "[{}::StepperVelocityEL70x1Device::stepper_velocity_state] Invalid Port",
+                    module_path!()
+                ));
+            }
         }
     }
 
-    fn get_input(
-        &self,
-        port: usize,
-    ) -> Result<StepperVelocityEL70x1Input, anyhow::Error> {
+    fn get_input(&self, port: usize) -> Result<StepperVelocityEL70x1Input, anyhow::Error> {
         // check if operating mode is velocity
         if self.configuration.stm_features.operation_mode != EL70x1OperationMode::DirectVelocity {
             return Err(anyhow!(
@@ -206,17 +203,14 @@ impl StepperVelocityEL70x1Device for EL7031_0030 {
             }
             _ => {
                 return Err(anyhow!(
-                            "[{}::StepperVelocityEL70x1Device::stepper_velocity_state] Invalid Port",
-                            module_path!()
-                        ));
-                } 
+                    "[{}::StepperVelocityEL70x1Device::stepper_velocity_state] Invalid Port",
+                    module_path!()
+                ));
+            }
         }
     }
 
-    fn get_output(
-        &self,
-        port: usize,
-    ) -> Result<StepperVelocityEL70x1Output, anyhow::Error> {
+    fn get_output(&self, port: usize) -> Result<StepperVelocityEL70x1Output, anyhow::Error> {
         // check if operating mode is velocity
         if self.configuration.stm_features.operation_mode != EL70x1OperationMode::DirectVelocity {
             return Err(anyhow!(
@@ -255,28 +249,25 @@ impl StepperVelocityEL70x1Device for EL7031_0030 {
                     reset: stm_control.reset,
                     set_counter: self.counter_wrapper.get_override(),
                 })
-            },
+            }
             _ => {
                 return Err(anyhow!(
-                            "[{}::StepperVelocityEL70x1Device::stepper_velocity_state] Invalid Port",
-                            module_path!()
-                        ));
-                } 
+                    "[{}::StepperVelocityEL70x1Device::stepper_velocity_state] Invalid Port",
+                    module_path!()
+                ));
+            }
         }
     }
 
-    fn get_speed_range(
-        &self,
-        _port: usize,
-    ) -> crate::shared_config::el70x1::EL70x1SpeedRange {
+    fn get_speed_range(&self, _port: usize) -> crate::shared_config::el70x1::EL70x1SpeedRange {
         self.configuration.stm_features.speed_range
     }
 
     fn get_port_count(&self) -> usize {
         1
     }
-    
-    fn get_analog_input(&self, port: usize) -> Result<AnalogInputInput,anyhow::Error> {
+
+    fn get_analog_input(&self, port: usize) -> Result<AnalogInputInput, anyhow::Error> {
         let (raw_value, wiring_error) = match port {
             0 => match &self.txpdo {
                 EL7031_0030TxPdo {
@@ -358,49 +349,51 @@ impl StepperVelocityEL70x1Device for EL7031_0030 {
         2
     }
 
-    fn is_enabled(&self,port : usize) -> bool {
+    fn is_enabled(&self, port: usize) -> bool {
         match self.get_output(port) {
             Ok(output) => output.enable,
             Err(_) => false,
         }
     }
 
-    fn get_position(&self,port : usize) -> i128 {
+    fn get_position(&self, port: usize) -> i128 {
         let input = self.get_input(port).unwrap();
         input.counter_value
     }
 
-    fn set_position(&mut self,port : usize, position: i128) {
+    fn set_position(&mut self, port: usize, position: i128) {
         let mut output = self.get_output(port).unwrap();
-        output.set_counter = Some(position);        
-        self.set_output(port,output).unwrap();
+        output.set_counter = Some(position);
+        self.set_output(port, output).unwrap();
     }
 
-    fn set_enabled(&mut self,port : usize, enabled: bool) {        
+    fn set_enabled(&mut self, port: usize, enabled: bool) {
         let mut output = self.get_output(port).unwrap();
         output.enable = enabled;
         self.set_output(port, output);
     }
 
-    fn set_speed(&mut self, port : usize, steps_per_second: f64) -> Result<(), anyhow::Error> {
+    fn set_speed(&mut self, port: usize, steps_per_second: f64) -> Result<(), anyhow::Error> {
         // Get current state to preserve other output values
         let mut output = self.get_output(port).unwrap();
 
         // Get speed range from device to convert steps to velocity
         let speed_range = self.get_speed_range(port);
-        let converter = crate::helpers::el70xx_velocity_converter::EL70x1VelocityConverter::new(&speed_range);
+        let converter =
+            crate::helpers::el70xx_velocity_converter::EL70x1VelocityConverter::new(&speed_range);
         let velocity = converter.steps_to_velocity(steps_per_second, true);
 
         output.velocity = velocity;
 
         // Write to device
-        self.set_output(port,output)
+        self.set_output(port, output)
     }
 
-    fn get_speed(&self, port : usize) -> i32 {
+    fn get_speed(&self, port: usize) -> i32 {
         let output = self.get_output(port).unwrap();
         let speed_range = self.get_speed_range(port);
-        let converter = crate::helpers::el70xx_velocity_converter::EL70x1VelocityConverter::new(&speed_range);
+        let converter =
+            crate::helpers::el70xx_velocity_converter::EL70x1VelocityConverter::new(&speed_range);
         converter.velocity_to_steps(output.velocity, true) as i32
     }
 }

--- a/ethercat_hal/src/devices/el7041_0052/mod.rs
+++ b/ethercat_hal/src/devices/el7041_0052/mod.rs
@@ -5,9 +5,10 @@ use super::{EthercatDeviceProcessing, NewEthercatDevice, SubDeviceIdentityTuple}
 use crate::{
     helpers::counter_wrapper_u16_i128::CounterWrapperU16U128,
     io::{
-        analog_input::AnalogInputInput, stepper_velocity_el70x1::{
+        analog_input::AnalogInputInput,
+        stepper_velocity_el70x1::{
             StepperVelocityEL70x1Device, StepperVelocityEL70x1Input, StepperVelocityEL70x1Output,
-        }
+        },
     },
     pdo::{PredefinedPdoAssignment, RxPdo, TxPdo},
     shared_config::el70x1::EL70x1OperationMode,
@@ -154,10 +155,7 @@ impl StepperVelocityEL70x1Device for EL7041_0052 {
         }
     }
 
-    fn get_input(
-        &self,
-        port: usize,
-    ) -> Result<StepperVelocityEL70x1Input, anyhow::Error> {
+    fn get_input(&self, port: usize) -> Result<StepperVelocityEL70x1Input, anyhow::Error> {
         // check if operating mode is velocity
         if self.configuration.stm_features.operation_mode != EL70x1OperationMode::DirectVelocity {
             return Err(anyhow!(
@@ -192,10 +190,7 @@ impl StepperVelocityEL70x1Device for EL7041_0052 {
         }
     }
 
-    fn get_output(
-        &self,
-        port: usize,
-    ) -> Result<StepperVelocityEL70x1Output, anyhow::Error> {
+    fn get_output(&self, port: usize) -> Result<StepperVelocityEL70x1Output, anyhow::Error> {
         // check if operating mode is velocity
         if self.configuration.stm_features.operation_mode != EL70x1OperationMode::DirectVelocity {
             return Err(anyhow!(
@@ -231,10 +226,7 @@ impl StepperVelocityEL70x1Device for EL7041_0052 {
         }
     }
 
-    fn get_speed_range(
-        &self,
-        _port: usize,
-    ) -> crate::shared_config::el70x1::EL70x1SpeedRange {
+    fn get_speed_range(&self, _port: usize) -> crate::shared_config::el70x1::EL70x1SpeedRange {
         self.configuration.stm_features.speed_range
     }
 
@@ -272,7 +264,7 @@ impl StepperVelocityEL70x1Device for EL7041_0052 {
         2
     }
 
-    fn get_analog_input(&self, _port: usize) -> Result<AnalogInputInput,anyhow::Error> {
+    fn get_analog_input(&self, _port: usize) -> Result<AnalogInputInput, anyhow::Error> {
         Err(anyhow!("EL7041_0052 has no analog_input!"))
     }
 
@@ -284,53 +276,54 @@ impl StepperVelocityEL70x1Device for EL7041_0052 {
         None
     }
 
-    fn is_enabled(&self,port : usize) -> bool {
+    fn is_enabled(&self, port: usize) -> bool {
         match self.get_output(port) {
             Ok(output) => output.enable,
             Err(_) => false,
         }
     }
 
-    fn get_position(&self,port : usize) -> i128 {
+    fn get_position(&self, port: usize) -> i128 {
         let input = self.get_input(port).unwrap();
         input.counter_value
     }
 
-    fn set_position(&mut self,port : usize, position: i128) {
+    fn set_position(&mut self, port: usize, position: i128) {
         let mut output = self.get_output(port).unwrap();
-        output.set_counter = Some(position);        
-        self.set_output(port,output).unwrap();
+        output.set_counter = Some(position);
+        self.set_output(port, output).unwrap();
     }
 
-    fn set_enabled(&mut self,port : usize, enabled: bool) {        
+    fn set_enabled(&mut self, port: usize, enabled: bool) {
         let mut output = self.get_output(port).unwrap();
         output.enable = enabled;
         self.set_output(port, output);
     }
 
-    fn set_speed(&mut self, port : usize, steps_per_second: f64) -> Result<(), anyhow::Error> {
+    fn set_speed(&mut self, port: usize, steps_per_second: f64) -> Result<(), anyhow::Error> {
         // Get current state to preserve other output values
         let mut output = self.get_output(port).unwrap();
 
         // Get speed range from device to convert steps to velocity
         let speed_range = self.get_speed_range(port);
-        let converter = crate::helpers::el70xx_velocity_converter::EL70x1VelocityConverter::new(&speed_range);
+        let converter =
+            crate::helpers::el70xx_velocity_converter::EL70x1VelocityConverter::new(&speed_range);
         let velocity = converter.steps_to_velocity(steps_per_second, true);
 
         output.velocity = velocity;
 
         // Write to device
-        self.set_output(port,output)
+        self.set_output(port, output)
     }
 
-    fn get_speed(&self, port : usize) -> i32 {
+    fn get_speed(&self, port: usize) -> i32 {
         let output = self.get_output(port).unwrap();
         let speed_range = self.get_speed_range(port);
-        let converter = crate::helpers::el70xx_velocity_converter::EL70x1VelocityConverter::new(&speed_range);
+        let converter =
+            crate::helpers::el70xx_velocity_converter::EL70x1VelocityConverter::new(&speed_range);
         converter.velocity_to_steps(output.velocity, true) as i32
     }
 }
-
 
 #[derive(Debug, Clone, Copy)]
 pub enum EL7041_0052Port {

--- a/ethercat_hal/src/devices/ep2339_0021.rs
+++ b/ethercat_hal/src/devices/ep2339_0021.rs
@@ -1,0 +1,354 @@
+use super::{EthercatDeviceProcessing, NewEthercatDevice};
+use crate::devices::SubDeviceIdentityTuple;
+use crate::io::digital_input::DigitalInputDevice;
+use crate::io::digital_output::DigitalOutputDevice;
+use crate::pdo::basic::BoolPdoObject;
+use crate::pdo::{RxPdo, TxPdo};
+use ethercat_hal_derive::{EthercatDevice, RxPdo, TxPdo};
+
+/// EP2339_0021 16-channel; digital input/output
+#[derive(EthercatDevice)]
+pub struct EP2339_0021 {
+    pub rxpdo: EP2339_0021RxPdo,
+    pub txpdo: EP2339_0021TxPdo,
+    is_used: bool,
+}
+
+impl EthercatDeviceProcessing for EP2339_0021 {}
+
+impl std::fmt::Debug for EP2339_0021 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EP2339_0021")
+    }
+}
+
+impl NewEthercatDevice for EP2339_0021 {
+    fn new() -> Self {
+        Self {
+            rxpdo: EP2339_0021RxPdo::default(),
+            txpdo: EP2339_0021TxPdo::default(),
+            is_used: false,
+        }
+    }
+}
+
+impl DigitalOutputDevice for EP2339_0021 {
+    fn set_output(&mut self, port: usize, value: bool) {
+        let expect_text = "All channels should be Some(_)";
+        match port {
+            0 => self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into(),
+            1 => self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into(),
+            2 => self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into(),
+            3 => self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into(),
+            4 => self.rxpdo.channel5.as_mut().expect(expect_text).value = value.into(),
+            5 => self.rxpdo.channel6.as_mut().expect(expect_text).value = value.into(),
+            6 => self.rxpdo.channel7.as_mut().expect(expect_text).value = value.into(),
+            7 => self.rxpdo.channel8.as_mut().expect(expect_text).value = value.into(),
+            8 => self.rxpdo.channel9.as_mut().expect(expect_text).value = value.into(),
+            9 => self.rxpdo.channel10.as_mut().expect(expect_text).value = value.into(),
+            10 => self.rxpdo.channel11.as_mut().expect(expect_text).value = value.into(),
+            11 => self.rxpdo.channel12.as_mut().expect(expect_text).value = value.into(),
+            12 => self.rxpdo.channel13.as_mut().expect(expect_text).value = value.into(),
+            13 => self.rxpdo.channel14.as_mut().expect(expect_text).value = value.into(),
+            14 => self.rxpdo.channel15.as_mut().expect(expect_text).value = value.into(),
+            15 => self.rxpdo.channel16.as_mut().expect(expect_text).value = value.into(),
+            _ => (),
+        }
+    }
+
+    fn get_port_count(&self) -> usize {
+        16
+    }
+}
+
+impl DigitalInputDevice for EP2339_0021 {
+    fn get_input(&self, port: usize) -> Result<bool, anyhow::Error> {
+        let val = match port {
+            0 => {
+                self.txpdo
+                    .channel1
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 1 not found")
+                    .value
+            }
+            1 => {
+                self.txpdo
+                    .channel2
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 2 not found")
+                    .value
+            }
+            2 => {
+                self.txpdo
+                    .channel3
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 3 not found")
+                    .value
+            }
+            3 => {
+                self.txpdo
+                    .channel4
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 4 not found")
+                    .value
+            }
+            4 => {
+                self.txpdo
+                    .channel5
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 5 not found")
+                    .value
+            }
+            5 => {
+                self.txpdo
+                    .channel6
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 6 not found")
+                    .value
+            }
+            6 => {
+                self.txpdo
+                    .channel7
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 7 not found")
+                    .value
+            }
+            7 => {
+                self.txpdo
+                    .channel8
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 8 not found")
+                    .value
+            }
+            8 => {
+                self.txpdo
+                    .channel9
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 9 not found")
+                    .value
+            }
+            9 => {
+                self.txpdo
+                    .channel10
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 10 not found")
+                    .value
+            }
+            10 => {
+                self.txpdo
+                    .channel11
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 11 not found")
+                    .value
+            }
+            11 => {
+                self.txpdo
+                    .channel12
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 12 not found")
+                    .value
+            }
+            12 => {
+                self.txpdo
+                    .channel13
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 13 not found")
+                    .value
+            }
+            13 => {
+                self.txpdo
+                    .channel14
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 14 not found")
+                    .value
+            }
+            14 => {
+                self.txpdo
+                    .channel15
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 15 not found")
+                    .value
+            }
+            15 => {
+                self.txpdo
+                    .channel16
+                    .as_ref()
+                    .expect("EP2339_0021 Channel 16 not found")
+                    .value
+            }
+            _ => return Err(anyhow::anyhow!("EP2339_0021 has 16 ports! (0-15)")),
+        };
+        Ok(val)
+    }
+
+    fn get_port_count(&self) -> usize {
+        16
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum EP2339_0021OutputPort {
+    DO1,
+    DO2,
+    DO3,
+    DO4,
+    DO5,
+    DO6,
+    DO7,
+    DO8,
+    DO9,
+    DO10,
+    DO11,
+    DO12,
+    DO13,
+    DO14,
+    DO15,
+    DO16,
+}
+
+#[derive(Debug, Clone)]
+pub enum EP2339_0021InputPort {
+    DI1,
+    DI2,
+    DI3,
+    DI4,
+    DI5,
+    DI6,
+    DI7,
+    DI8,
+    DI9,
+    DI10,
+    DI11,
+    DI12,
+    DI13,
+    DI14,
+    DI15,
+    DI16,
+}
+
+#[derive(Debug, Clone, RxPdo)]
+pub struct EP2339_0021RxPdo {
+    #[pdo_object_index(0x1600)]
+    pub channel1: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1601)]
+    pub channel2: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1602)]
+    pub channel3: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1603)]
+    pub channel4: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1604)]
+    pub channel5: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1605)]
+    pub channel6: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1606)]
+    pub channel7: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1607)]
+    pub channel8: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1608)]
+    pub channel9: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1609)]
+    pub channel10: Option<BoolPdoObject>,
+    #[pdo_object_index(0x160A)]
+    pub channel11: Option<BoolPdoObject>,
+    #[pdo_object_index(0x160B)]
+    pub channel12: Option<BoolPdoObject>,
+    #[pdo_object_index(0x160C)]
+    pub channel13: Option<BoolPdoObject>,
+    #[pdo_object_index(0x160D)]
+    pub channel14: Option<BoolPdoObject>,
+    #[pdo_object_index(0x160E)]
+    pub channel15: Option<BoolPdoObject>,
+    #[pdo_object_index(0x160F)]
+    pub channel16: Option<BoolPdoObject>,
+}
+
+impl Default for EP2339_0021RxPdo {
+    fn default() -> Self {
+        Self {
+            channel1: Some(BoolPdoObject::default()),
+            channel2: Some(BoolPdoObject::default()),
+            channel3: Some(BoolPdoObject::default()),
+            channel4: Some(BoolPdoObject::default()),
+            channel5: Some(BoolPdoObject::default()),
+            channel6: Some(BoolPdoObject::default()),
+            channel7: Some(BoolPdoObject::default()),
+            channel8: Some(BoolPdoObject::default()),
+            channel9: Some(BoolPdoObject::default()),
+            channel10: Some(BoolPdoObject::default()),
+            channel11: Some(BoolPdoObject::default()),
+            channel12: Some(BoolPdoObject::default()),
+            channel13: Some(BoolPdoObject::default()),
+            channel14: Some(BoolPdoObject::default()),
+            channel15: Some(BoolPdoObject::default()),
+            channel16: Some(BoolPdoObject::default()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, TxPdo)]
+pub struct EP2339_0021TxPdo {
+    #[pdo_object_index(0x1A00)]
+    pub channel1: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A01)]
+    pub channel2: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A02)]
+    pub channel3: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A03)]
+    pub channel4: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A04)]
+    pub channel5: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A05)]
+    pub channel6: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A06)]
+    pub channel7: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A07)]
+    pub channel8: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A08)]
+    pub channel9: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A09)]
+    pub channel10: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A0A)]
+    pub channel11: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A0B)]
+    pub channel12: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A0C)]
+    pub channel13: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A0D)]
+    pub channel14: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A0E)]
+    pub channel15: Option<BoolPdoObject>,
+    #[pdo_object_index(0x1A0F)]
+    pub channel16: Option<BoolPdoObject>,
+}
+
+impl Default for EP2339_0021TxPdo {
+    fn default() -> Self {
+        Self {
+            channel1: Some(BoolPdoObject::default()),
+            channel2: Some(BoolPdoObject::default()),
+            channel3: Some(BoolPdoObject::default()),
+            channel4: Some(BoolPdoObject::default()),
+            channel5: Some(BoolPdoObject::default()),
+            channel6: Some(BoolPdoObject::default()),
+            channel7: Some(BoolPdoObject::default()),
+            channel8: Some(BoolPdoObject::default()),
+            channel9: Some(BoolPdoObject::default()),
+            channel10: Some(BoolPdoObject::default()),
+            channel11: Some(BoolPdoObject::default()),
+            channel12: Some(BoolPdoObject::default()),
+            channel13: Some(BoolPdoObject::default()),
+            channel14: Some(BoolPdoObject::default()),
+            channel15: Some(BoolPdoObject::default()),
+            channel16: Some(BoolPdoObject::default()),
+        }
+    }
+}
+
+pub const EP2339_0021_VENDOR_ID: u32 = 0x2;
+pub const EP2339_0021_PRODUCT_ID_A: u32 = 0x9234052;
+pub const EP2339_0021_REVISION_A: u32 = 0x130015;
+pub const EP2339_0021_IDENTITY_A: SubDeviceIdentityTuple = (
+    EP2339_0021_VENDOR_ID,
+    EP2339_0021_PRODUCT_ID_A,
+    EP2339_0021_REVISION_A,
+);

--- a/ethercat_hal/src/devices/ep2339_0021.rs
+++ b/ethercat_hal/src/devices/ep2339_0021.rs
@@ -63,7 +63,7 @@ impl DigitalOutputDevice for EP2339_0021 {
 
 impl DigitalInputDevice for EP2339_0021 {
     fn get_input(&self, port: usize) -> Result<bool, anyhow::Error> {
-                let error = anyhow::anyhow!(
+        let error = anyhow::anyhow!(
             "[{}::Device::digital_input_state] Port index {} is not available",
             module_path!(),
             port
@@ -87,11 +87,10 @@ impl DigitalInputDevice for EP2339_0021 {
             14 => Ok(self.txpdo.channel15.as_ref().ok_or(error)?.value),
             15 => Ok(self.txpdo.channel16.as_ref().ok_or(error)?.value),
             _ => Err(anyhow::anyhow!(
-                "EL1002 has 2 ports (0-1), requested index {}",
+                "EP2339 has 16 ports (0-15), requested index {}",
                 port
             )),
         }
-
     }
 
     fn get_port_count(&self) -> usize {

--- a/ethercat_hal/src/devices/ep2339_0021.rs
+++ b/ethercat_hal/src/devices/ep2339_0021.rs
@@ -63,122 +63,35 @@ impl DigitalOutputDevice for EP2339_0021 {
 
 impl DigitalInputDevice for EP2339_0021 {
     fn get_input(&self, port: usize) -> Result<bool, anyhow::Error> {
-        let val = match port {
-            0 => {
-                self.txpdo
-                    .channel1
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 1 not found")
-                    .value
-            }
-            1 => {
-                self.txpdo
-                    .channel2
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 2 not found")
-                    .value
-            }
-            2 => {
-                self.txpdo
-                    .channel3
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 3 not found")
-                    .value
-            }
-            3 => {
-                self.txpdo
-                    .channel4
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 4 not found")
-                    .value
-            }
-            4 => {
-                self.txpdo
-                    .channel5
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 5 not found")
-                    .value
-            }
-            5 => {
-                self.txpdo
-                    .channel6
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 6 not found")
-                    .value
-            }
-            6 => {
-                self.txpdo
-                    .channel7
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 7 not found")
-                    .value
-            }
-            7 => {
-                self.txpdo
-                    .channel8
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 8 not found")
-                    .value
-            }
-            8 => {
-                self.txpdo
-                    .channel9
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 9 not found")
-                    .value
-            }
-            9 => {
-                self.txpdo
-                    .channel10
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 10 not found")
-                    .value
-            }
-            10 => {
-                self.txpdo
-                    .channel11
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 11 not found")
-                    .value
-            }
-            11 => {
-                self.txpdo
-                    .channel12
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 12 not found")
-                    .value
-            }
-            12 => {
-                self.txpdo
-                    .channel13
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 13 not found")
-                    .value
-            }
-            13 => {
-                self.txpdo
-                    .channel14
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 14 not found")
-                    .value
-            }
-            14 => {
-                self.txpdo
-                    .channel15
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 15 not found")
-                    .value
-            }
-            15 => {
-                self.txpdo
-                    .channel16
-                    .as_ref()
-                    .expect("EP2339_0021 Channel 16 not found")
-                    .value
-            }
-            _ => return Err(anyhow::anyhow!("EP2339_0021 has 16 ports! (0-15)")),
-        };
-        Ok(val)
+                let error = anyhow::anyhow!(
+            "[{}::Device::digital_input_state] Port index {} is not available",
+            module_path!(),
+            port
+        );
+
+        match port {
+            0 => Ok(self.txpdo.channel1.as_ref().ok_or(error)?.value),
+            1 => Ok(self.txpdo.channel2.as_ref().ok_or(error)?.value),
+            2 => Ok(self.txpdo.channel3.as_ref().ok_or(error)?.value),
+            3 => Ok(self.txpdo.channel4.as_ref().ok_or(error)?.value),
+            4 => Ok(self.txpdo.channel5.as_ref().ok_or(error)?.value),
+            5 => Ok(self.txpdo.channel6.as_ref().ok_or(error)?.value),
+            6 => Ok(self.txpdo.channel7.as_ref().ok_or(error)?.value),
+            7 => Ok(self.txpdo.channel8.as_ref().ok_or(error)?.value),
+            8 => Ok(self.txpdo.channel9.as_ref().ok_or(error)?.value),
+            9 => Ok(self.txpdo.channel10.as_ref().ok_or(error)?.value),
+            10 => Ok(self.txpdo.channel11.as_ref().ok_or(error)?.value),
+            11 => Ok(self.txpdo.channel12.as_ref().ok_or(error)?.value),
+            12 => Ok(self.txpdo.channel13.as_ref().ok_or(error)?.value),
+            13 => Ok(self.txpdo.channel14.as_ref().ok_or(error)?.value),
+            14 => Ok(self.txpdo.channel15.as_ref().ok_or(error)?.value),
+            15 => Ok(self.txpdo.channel16.as_ref().ok_or(error)?.value),
+            _ => Err(anyhow::anyhow!(
+                "EL1002 has 2 ports (0-1), requested index {}",
+                port
+            )),
+        }
+
     }
 
     fn get_port_count(&self) -> usize {

--- a/ethercat_hal/src/devices/mod.rs
+++ b/ethercat_hal/src/devices/mod.rs
@@ -27,6 +27,8 @@ pub mod wago_750_354;
 pub mod wago_modules;
 
 use crate::MetaSubdevice;
+use crate::devices::ep2339_0021::EP2339_0021_IDENTITY_A;
+use crate::devices::panasonic_modules::minas_a6::{self, MINAS_A6_IDENTITY_A};
 
 use super::devices::el1008::EL1008;
 use bitvec::order::Lsb0;
@@ -189,6 +191,8 @@ pub fn device_from_subdevice_identity(
         EL2521_IDENTITY_0000_A | EL2521_IDENTITY_0000_B | EL2521_IDENTITY_0024_A => {
             Ok(Box::new(EL2521::new()))
         }
+        EP2339_0021_IDENTITY_A => Ok(Box::new(ep2339_0021::EP2339_0021::new())),
+        MINAS_A6_IDENTITY_A => Ok(Box::new(minas_a6::MinasA6BMotor::new())),
         _ => Err(anyhow::anyhow!(
             "[{}::device_from_subdevice] No Driver: vendor_id: 0x{:x}, product_id: 0x{:x}, revision: 0x{:x}",
             module_path!(),
@@ -236,6 +240,8 @@ pub fn device_from_subdevice_identity_rc(
         EL2521_IDENTITY_0000_A | EL2521_IDENTITY_0000_B | EL2521_IDENTITY_0024_A => {
             Ok(Rc::new(RefCell::new(EL2521::new())))
         }
+        EP2339_0021_IDENTITY_A => Ok(Rc::new(RefCell::new(ep2339_0021::EP2339_0021::new()))),
+        MINAS_A6_IDENTITY_A => Ok(Rc::new(RefCell::new(minas_a6::MinasA6BMotor::new()))),
 
         _ => Err(anyhow::anyhow!(
             "[{}::device_from_subdevice] No Driver: vendor_id: 0x{:x}, product_id: 0x{:x}, revision: 0x{:x}",

--- a/ethercat_hal/src/devices/mod.rs
+++ b/ethercat_hal/src/devices/mod.rs
@@ -21,6 +21,7 @@ pub mod el7031;
 pub mod el7031_0030;
 pub mod el7041_0052;
 
+pub mod panasonic_modules;
 pub mod wago_750_354;
 pub mod wago_modules;
 

--- a/ethercat_hal/src/devices/mod.rs
+++ b/ethercat_hal/src/devices/mod.rs
@@ -20,6 +20,7 @@ pub mod el6021;
 pub mod el7031;
 pub mod el7031_0030;
 pub mod el7041_0052;
+pub mod ep2339_0021;
 
 pub mod panasonic_modules;
 pub mod wago_750_354;

--- a/ethercat_hal/src/devices/panasonic_modules/minas_a6.rs
+++ b/ethercat_hal/src/devices/panasonic_modules/minas_a6.rs
@@ -1,0 +1,1493 @@
+//! MinasA6B motor driver (CiA 402, PP-motion mode) for EtherCrab.
+//!
+//! PDO I/O
+//!   - `input()`: unpack raw bytes from a `BitSlice` via `load_le` into a `TxPdo` struct.
+//!   - `output()`: pack a `RxPdo` struct into raw bytes and write them via `store_le`.
+
+use crate::coe::ConfigurableDevice;
+use crate::devices::{
+    EthercatDevice, EthercatDeviceProcessing, EthercatDeviceUsed, EthercatDynamicPDO, Module,
+    NewEthercatDevice, SubDeviceIdentityTuple,
+};
+use crate::helpers::ethercrab_types::EthercrabSubDevicePreoperational;
+use crate::helpers::minas_a6_subdevice_wrapper::{EtherCATSlaveWrapper, PdoMapping};
+use crate::io::servo_velocity_minasa6::{MinasA6BDevice, MinasA6BInput, MinasA6BOutput};
+use anyhow::{Error, anyhow};
+use bitvec::field::BitField;
+use bitvec::prelude::{BitSlice, Lsb0};
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+// Motor registers
+
+pub struct Reg;
+
+impl Reg {
+    pub const EEPROM: u16 = 0x1010;
+    pub const ENCODER_SETTING: u16 = 0x3015;
+    pub const CONTROL_INPUT_SI_FUNCTION_ASSIGNMENT: u16 = 0x3400;
+    pub const ENCODER_MULTI_TURN_DATA_CLEAR_TRIGGER: u16 = 0x4D00; // set from 0->1->0 after the register below has been set to 0x31
+    pub const ENCODER_MULTI_TURN_DATA_CLEAR: u16 = 0x4D01; // set to 0x31 to clear the encoder data
+    pub const SET_MODE_OF_OPERATION: u16 = 0x6060; // set tot 1 for pp mode
+    pub const GET_MODE_OF_OPERATION: u16 = 0x6061;
+    pub const POSITION_TARGET: u16 = 0x607A; // encoder-pulses
+    pub const POSITION_ACTUAL: u16 = 0x6064; // encoder-pulses
+    pub const TARGET_VELOCITY: u16 = 0x6081; // encoder-pulses/s
+    pub const MAX_VELOCITY: u16 = 0x607F; // encoder-pulses/s
+    pub const MAX_SPEED: u16 = 0x6080; // 1/min
+    pub const TARGET_ACCELERATION: u16 = 0x6083; // encoder-pulses/s²
+    pub const TARGET_DECELERATION: u16 = 0x6084; // encoder-pulses/s
+    pub const ENCODER_RESOLUTION: u16 = 0x608F;
+    pub const MAX_ACCELERATION: u16 = 0x60C5; // encoder-pulses/s
+
+    pub const ERROR_CODE: u16 = 0x603F;
+    pub const MAX_TORQUE: u16 = 0x6072; // in 0.1%
+
+    pub const HOMING_MODE: u16 = 0x6098;
+    pub const HOMING_SPEED: u16 = 0x6099; // first subindex: fast homing speed, second subindex: slow homing speed
+    pub const HOMING_ACC: u16 = 0x609A;
+    pub const HOMING_OFFSET: u16 = 0x607C;
+
+    pub const FOLLOWING_WINDOW: u16 = 0x6065; // encoder-pulses
+    pub const FOLLOWING_WINDOW_TIME: u16 = 0x6066; // ms
+    pub const POSITION_WINDOW: u16 = 0x6067; // encoder-pulses
+    pub const POSITION_WINDOW_TIME: u16 = 0x6068; // ms
+    pub const POSITIONING_OPTION: u16 = 0x60F2;
+
+    pub const CONTROL_WORD: u16 = 0x6040;
+    pub const STATUS_WORD: u16 = 0x6041;
+
+    pub const RX_PDO: u16 = 0x1600; // master -> slave
+    pub const TX_PDO: u16 = 0x1A00; // slave -> master
+    pub const RX_PDO_ASSIGN_ADDRESS: u16 = 0x1C12;
+    pub const TX_PDO_ASSIGN_ADDRESS: u16 = 0x1C13;
+
+    pub const CONTROL_WORD_DISABLE: u16 = 0x0000;
+    pub const CONTROL_WORD_READY_TO_SWITCH_ON: u16 = 0x0006;
+    pub const CONTROL_WORD_SWITCH_ON: u16 = 0x0007;
+    pub const CONTROL_WORD_ENABLE: u16 = 0x000F;
+}
+
+impl Reg {
+    // CiA 402 control words
+    pub const CW_FAULT_RESET: u16 = 0x0080;
+    pub const CW_QUICK_STOP: u16 = 0x0002;
+}
+
+pub struct MotorMode;
+impl MotorMode {
+    pub const PP: u8 = 1;
+    pub const HOMING: u8 = 6;
+}
+
+// InputPdo  (slave -> master, TxPDO):  9 bytes
+//   [0..1]  StatusWord  (u16 LE)
+//   [2]     ModeDisplay (u8)
+//   [3..4]  ErrorCode   (u16 LE)
+//   [5..8]  PositionActual (i32 LE)
+//
+// OutputPdo (master -> slave, RxPDO): 19 bytes
+//   [0..1]  ControlWord      (u16 LE)
+//   [2]     Mode             (u8)
+//   [3..6]  TargetPosition   (i32 LE)
+//   [7..10] TargetVelocity   (u32 LE)
+//   [11..14] TargetAccel     (u32 LE)
+//   [15..18] TargetDecel     (u32 LE)
+
+pub const TX_PDO_BYTES: usize = 9;
+pub const RX_PDO_BYTES: usize = 19;
+
+#[derive(Clone, Debug, Default)]
+pub struct MinasA6BTxPdo {
+    pub status_word: u16,
+    pub mode_display: u8,
+    pub error_code: u16,
+    pub position_actual: i32,
+}
+
+impl MinasA6BTxPdo {
+    pub fn from_bitslice(input: &BitSlice<u8, Lsb0>, bit_offset: usize) -> Self {
+        let mut b = [0u8; TX_PDO_BYTES];
+        for i in 0..TX_PDO_BYTES {
+            b[i] = input[bit_offset + i * 8..bit_offset + (i + 1) * 8].load_le();
+        }
+        Self {
+            status_word: u16::from_le_bytes([b[0], b[1]]),
+            mode_display: b[2],
+            error_code: u16::from_le_bytes([b[3], b[4]]),
+            position_actual: i32::from_le_bytes([b[5], b[6], b[7], b[8]]),
+        }
+    }
+}
+
+/// Data sent to the drive each cycle (RxPDO: master -> slave).
+#[derive(Clone, Debug, Default)]
+pub struct MinasA6BRxPdo {
+    pub control_word: u16,
+    pub mode: u8,
+    pub target_position: i32,
+    pub target_velocity: u32,
+    pub target_accel: u32,
+    pub target_decel: u32,
+}
+
+impl MinasA6BRxPdo {
+    pub fn to_bitslice(&self, output: &mut BitSlice<u8, Lsb0>, bit_offset: usize) {
+        let cw = self.control_word.to_le_bytes();
+        let tp = self.target_position.to_le_bytes();
+        let tv = self.target_velocity.to_le_bytes();
+        let ta = self.target_accel.to_le_bytes();
+        let td = self.target_decel.to_le_bytes();
+
+        let bytes: [u8; RX_PDO_BYTES] = [
+            cw[0], cw[1], self.mode, tp[0], tp[1], tp[2], tp[3], tv[0], tv[1], tv[2], tv[3], ta[0],
+            ta[1], ta[2], ta[3], td[0], td[1], td[2], td[3],
+        ];
+
+        for i in 0..RX_PDO_BYTES {
+            output[bit_offset + i * 8..bit_offset + (i + 1) * 8].store_le(bytes[i]);
+        }
+    }
+}
+
+pub const SET_DATA_MAPPING: [PdoMapping; 6] = [
+    PdoMapping {
+        object_index: Reg::CONTROL_WORD,
+        sub_index: 0,
+        bit_length: 16,
+    },
+    PdoMapping {
+        object_index: Reg::SET_MODE_OF_OPERATION,
+        sub_index: 0,
+        bit_length: 8,
+    },
+    PdoMapping {
+        object_index: Reg::POSITION_TARGET,
+        sub_index: 0,
+        bit_length: 32,
+    },
+    PdoMapping {
+        object_index: Reg::TARGET_VELOCITY,
+        sub_index: 0,
+        bit_length: 32,
+    },
+    PdoMapping {
+        object_index: Reg::TARGET_ACCELERATION,
+        sub_index: 0,
+        bit_length: 32,
+    },
+    PdoMapping {
+        object_index: Reg::TARGET_DECELERATION,
+        sub_index: 0,
+        bit_length: 32,
+    },
+];
+
+pub const GET_DATA_MAPPING: [PdoMapping; 4] = [
+    PdoMapping {
+        object_index: Reg::STATUS_WORD,
+        sub_index: 0,
+        bit_length: 16,
+    },
+    PdoMapping {
+        object_index: Reg::GET_MODE_OF_OPERATION,
+        sub_index: 0,
+        bit_length: 8,
+    },
+    PdoMapping {
+        object_index: Reg::ERROR_CODE,
+        sub_index: 0,
+        bit_length: 16,
+    },
+    PdoMapping {
+        object_index: Reg::POSITION_ACTUAL,
+        sub_index: 0,
+        bit_length: 32,
+    },
+];
+
+// State machine
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum State {
+    Unknown,
+    PreOpNotRdyToSwitchOn,
+    PreOpSwitchOnDisabled,
+    PreOpReadyToSwitchOn,
+    Ready,
+    RunIdle,
+    RunSentMotionCommand,
+    RunSentSetPointAck,
+    RunWaitForSendingNextCommand,
+    RunSentSetPointNack,
+    RunExecuting,
+    HomingIdle,
+    HomingSendingHomeCommand,
+    HomingWaitForFinish,
+    HomingWaitForModeChange,
+    QuickStopWaiting,
+    QuickStopReached,
+    ErrorAny,
+    ErrorEncoder,
+    ErrorGeneric,
+    ErrorResetToggled,
+}
+
+impl State {
+    pub fn is_error(self) -> bool {
+        matches!(
+            self,
+            Self::ErrorAny | Self::ErrorEncoder | Self::ErrorGeneric | Self::ErrorResetToggled
+        )
+    }
+    pub fn is_run(self) -> bool {
+        matches!(
+            self,
+            Self::RunIdle
+                | Self::RunSentMotionCommand
+                | Self::RunSentSetPointAck
+                | Self::RunWaitForSendingNextCommand
+                | Self::RunSentSetPointNack
+                | Self::RunExecuting
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HomingDirection {
+    /// Counter-clockwise: Panasonic homing mode 21.
+    Ccw,
+    /// Clockwise: Panasonic homing mode 19.
+    Cw,
+}
+
+impl HomingDirection {
+    pub fn mode_code(self) -> u8 {
+        match self {
+            HomingDirection::Ccw => 21,
+            HomingDirection::Cw => 19,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MotorHomingConfig {
+    pub homing_direction: HomingDirection,
+    pub high_speed_rps: f64,
+    pub slow_speed_rps: f64,
+    pub acceleration_rps_squared: f64,
+}
+
+impl Default for MotorHomingConfig {
+    fn default() -> Self {
+        Self {
+            homing_direction: HomingDirection::Ccw,
+            high_speed_rps: 0.5,
+            slow_speed_rps: 0.05,
+            acceleration_rps_squared: 10.0,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct EncoderResolution {
+    pub increments: u32,
+    pub revolutions: u32,
+}
+
+impl EncoderResolution {
+    fn ratio(&self) -> f64 {
+        self.increments as f64 / self.revolutions as f64
+    }
+
+    pub fn to_increments(&self, revolutions: f64, residue: &mut f64, is_absolute: bool) -> i32 {
+        let f = if is_absolute {
+            revolutions * self.ratio()
+        } else {
+            revolutions * self.ratio() + *residue
+        };
+        let i = f.floor() as i32;
+        *residue = f - i as f64;
+        i
+    }
+
+    pub fn to_revolutions(&self, increments: i32) -> f64 {
+        increments as f64 / self.ratio()
+    }
+
+    pub fn rps_to_inc_per_sec(&self, rps: f64) -> u32 {
+        (rps * self.ratio()) as u32
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PositionSpec {
+    pub n_revolutions: f64,
+    pub is_absolute: bool,
+    pub speed_rps: f64,
+    pub acceleration_rps2: f64,
+    pub deceleration_rps2: f64,
+}
+
+impl PositionSpec {
+    pub fn new(
+        n_revolutions: f64,
+        is_absolute: bool,
+        speed_rps: f64,
+        acceleration_rps2: f64,
+        deceleration_rps2: f64,
+    ) -> Result<Self, Error> {
+        if !n_revolutions.is_finite() {
+            return Err(anyhow!("n_revolutions must be finite, got {n_revolutions}"));
+        }
+        for (name, v) in [
+            ("speed_rps", speed_rps),
+            ("acceleration_rps2", acceleration_rps2),
+            ("deceleration_rps2", deceleration_rps2),
+        ] {
+            if !v.is_finite() || v <= 0.0 {
+                return Err(anyhow!(
+                    "{name} must be finite and > 0 (got {v}); control direction via the sign of n_revolutions"
+                ));
+            }
+        }
+        Ok(Self {
+            n_revolutions,
+            is_absolute,
+            speed_rps,
+            acceleration_rps2,
+            deceleration_rps2,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PositionTransitionSpec {
+    pub overlap: bool,
+    pub delay_ms: f64,
+}
+
+// MinasA6BMotor
+
+pub struct MinasA6BMotor {
+    is_used: bool,
+    tx_bit_offset: usize,
+    rx_bit_offset: usize,
+    pub module: Option<Module>,
+
+    pub txpdo: MinasA6BTxPdo,
+    pub rxpdo: MinasA6BRxPdo,
+
+    // State machine
+    pub state: State,
+
+    // Encoder
+    encoder_resolution: Option<EncoderResolution>,
+    pulse_residue: f64,
+
+    // Motion queue
+    motion_out_deque: VecDeque<MinasA6BRxPdo>,
+    motion_transition: Option<PositionTransitionSpec>,
+    current_motion_command: Option<MinasA6BRxPdo>,
+    previous_motion_command: Option<MinasA6BRxPdo>,
+    movement_delay: Option<Instant>,
+
+    // Mode tracking
+    current_motor_mode: u8,
+
+    // Control flags and timers
+    single_enable_flag: bool,
+    single_disable_flag: bool,
+    last_fault_reset_toggle: Option<Instant>,
+    mode_change_issued: Option<Instant>,
+    homing_issued: Option<Instant>,
+    pub needs_homing: bool,
+
+    pub homing_config: MotorHomingConfig,
+    pub initialized: bool,
+
+    pub homed: bool,
+}
+
+impl Default for MinasA6BMotor {
+    fn default() -> Self {
+        Self {
+            is_used: false,
+            tx_bit_offset: 0,
+            rx_bit_offset: 0,
+            module: None,
+            txpdo: MinasA6BTxPdo::default(),
+            rxpdo: MinasA6BRxPdo::default(),
+            state: State::Unknown,
+            encoder_resolution: None,
+            pulse_residue: 0.0,
+            motion_out_deque: VecDeque::with_capacity(100),
+            motion_transition: None,
+            current_motion_command: None,
+            previous_motion_command: None,
+            movement_delay: None,
+            current_motor_mode: MotorMode::PP,
+            single_enable_flag: false,
+            single_disable_flag: false,
+            last_fault_reset_toggle: None,
+            mode_change_issued: None,
+            homing_issued: None,
+            needs_homing: false,
+            homing_config: MotorHomingConfig::default(),
+            initialized: false,
+            homed: false,
+        }
+    }
+}
+
+// Trait implementations
+
+impl NewEthercatDevice for MinasA6BMotor {
+    fn new() -> Self {
+        Self {
+            is_used: false,
+            tx_bit_offset: 0,
+            rx_bit_offset: 0,
+            module: None,
+            txpdo: MinasA6BTxPdo::default(),
+            rxpdo: MinasA6BRxPdo::default(),
+            state: State::Unknown,
+            encoder_resolution: None,
+            pulse_residue: 0.0,
+            motion_out_deque: VecDeque::with_capacity(100),
+            motion_transition: None,
+            current_motion_command: None,
+            previous_motion_command: None,
+            movement_delay: None,
+            current_motor_mode: MotorMode::PP,
+            single_enable_flag: false,
+            single_disable_flag: false,
+            last_fault_reset_toggle: None,
+            mode_change_issued: None,
+            homing_issued: None,
+            needs_homing: false,
+            homing_config: MotorHomingConfig::default(),
+            initialized: false,
+            homed: false,
+        }
+    }
+}
+
+impl EthercatDeviceUsed for MinasA6BMotor {
+    fn is_used(&self) -> bool {
+        self.is_used
+    }
+    fn set_used(&mut self, used: bool) {
+        self.is_used = used;
+    }
+}
+
+impl EthercatDynamicPDO for MinasA6BMotor {
+    fn get_tx_offset(&self) -> usize {
+        self.tx_bit_offset
+    }
+    fn get_rx_offset(&self) -> usize {
+        self.rx_bit_offset
+    }
+    fn set_tx_offset(&mut self, offset: usize) {
+        self.tx_bit_offset = offset;
+    }
+    fn set_rx_offset(&mut self, offset: usize) {
+        self.rx_bit_offset = offset;
+    }
+}
+
+impl EthercatDeviceProcessing for MinasA6BMotor {}
+
+impl EthercatDevice for MinasA6BMotor {
+    fn into_any_boxed(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
+    }
+    fn input(&mut self, input: &BitSlice<u8, Lsb0>) -> Result<(), Error> {
+        self.txpdo = MinasA6BTxPdo::from_bitslice(input, self.tx_bit_offset);
+        self.poll();
+        Ok(())
+    }
+
+    fn input_len(&self) -> usize {
+        TX_PDO_BYTES * 8
+    }
+
+    fn output(&self, output: &mut BitSlice<u8, Lsb0>) -> Result<(), Error> {
+        self.rxpdo.to_bitslice(output, self.rx_bit_offset);
+        Ok(())
+    }
+
+    fn output_len(&self) -> usize {
+        RX_PDO_BYTES * 8
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+    fn is_module(&self) -> bool {
+        true
+    }
+
+    fn get_module(&self) -> Option<Module> {
+        self.module.clone()
+    }
+
+    fn set_module(&mut self, module: Module) {
+        self.tx_bit_offset = module.tx_offset;
+        self.rx_bit_offset = module.rx_offset;
+        self.module = Some(module);
+    }
+
+    fn input_checked(&mut self, input: &BitSlice<u8, Lsb0>) -> Result<(), Error> {
+        let expected = self.input_len();
+        let actual = input.len();
+        if actual != expected {
+            return Err(anyhow!(
+                "[{}::input_checked] got {} bits ({} bytes), expected {} bits ({} bytes)",
+                module_path!(),
+                actual,
+                actual / 8,
+                expected,
+                expected / 8
+            ));
+        }
+        self.input(input)
+    }
+
+    fn output_checked(&self, output: &mut BitSlice<u8, Lsb0>) -> Result<(), Error> {
+        let expected = self.output_len();
+        let actual = output.len();
+        if actual != expected {
+            return Err(anyhow!(
+                "[{}::output_checked] got {} bits ({} bytes), expected {} bits ({} bytes)",
+                module_path!(),
+                actual,
+                actual / 8,
+                expected,
+                expected / 8
+            ));
+        }
+        self.output(output)
+    }
+}
+
+impl std::fmt::Debug for MinasA6BMotor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MinasA6BMotor(state={:?})", self.state)
+    }
+}
+
+impl MinasA6BMotor {
+    // This is for Debugging
+    pub async fn read_digital_inputs<'a>(
+        &self,
+        device: &'a EthercrabSubDevicePreoperational<'a>,
+    ) -> Result<u32, Error> {
+        let w = EtherCATSlaveWrapper::new(device);
+        let di = w.read_sdo_u32(0x60FD, 0).await?;
+        tracing::info!("Drive digital inputs 0x60FD: 0x{:08X}", di);
+        tracing::info!(
+            "  SI1={} SI2={} SI3={} SI4={} SI5={} SI6={} SI7={} SI8={}",
+            (di >> 0) & 1, // SI1
+            (di >> 1) & 1, // SI2
+            (di >> 2) & 1, // SI3
+            (di >> 3) & 1, // SI4
+            (di >> 4) & 1, // SI5
+            (di >> 5) & 1, // SI6
+            (di >> 6) & 1, // SI7
+            (di >> 7) & 1, // SI8
+        );
+        Ok(di)
+    }
+    pub async fn write_input_pin_functions<'a>(
+        &self,
+        device: &'a EthercrabSubDevicePreoperational<'a>,
+    ) -> Result<(), Error> {
+        let w = EtherCATSlaveWrapper::new(device);
+        let function_values: [u32; 8] = [
+            0x00323232, // SI1
+            0x00818181, // SI2
+            0x00828282, // SI3
+            0x00272727, // SI4
+            0x00222222, // SI5
+            0x00212121, // SI6
+            0x00303030, // SI7
+            0x00313131, // SI8
+        ];
+        for (i, &val) in function_values.iter().enumerate() {
+            w.write_sdo_i32(
+                Reg::CONTROL_INPUT_SI_FUNCTION_ASSIGNMENT + i as u16,
+                0,
+                val as i32,
+            )
+            .await?;
+        }
+        // Persist to EEPROM
+        w.write_sdo_u32(Reg::EEPROM, 1, 0x65766173).await?;
+        tracing::info!("EEPROM written with SI input pin configuration.");
+        Ok(())
+    }
+}
+
+// Async SDO configuration (called during pre-op, before OP transition)
+
+impl MinasA6BMotor {
+    pub async fn configure<'a>(
+        &self,
+        device: &'a EthercrabSubDevicePreoperational<'a>,
+    ) -> Result<(), Error> {
+        let w = EtherCATSlaveWrapper::new(device);
+
+        w.configure_pdo_mapping(Reg::RX_PDO, &SET_DATA_MAPPING)
+            .await?;
+        w.configure_pdo_mapping(Reg::TX_PDO, &GET_DATA_MAPPING)
+            .await?;
+        w.assign_pdos(Reg::RX_PDO_ASSIGN_ADDRESS, &[Reg::RX_PDO])
+            .await?;
+        w.assign_pdos(Reg::TX_PDO_ASSIGN_ADDRESS, &[Reg::TX_PDO])
+            .await?;
+
+        w.write_sdo_u16(Reg::POSITIONING_OPTION, 0, 0).await?;
+        w.write_sdo_u32(Reg::POSITION_WINDOW, 0, 10_000).await?;
+        w.write_sdo_u16(Reg::POSITION_WINDOW_TIME, 0, 0).await?;
+        w.write_sdo_u32(Reg::FOLLOWING_WINDOW, 0, 100).await?;
+        w.write_sdo_u16(Reg::FOLLOWING_WINDOW_TIME, 0, 1).await?;
+        w.write_sdo_i16(Reg::ENCODER_SETTING, 0, 0).await?; // absolute encoder
+        w.write_sdo_u16(Reg::MAX_TORQUE, 0, 500).await?; // 50.0 %
+
+        Ok(())
+    }
+
+    /// Read and store the encoder resolution from the drive.
+    pub async fn read_encoder_resolution<'a>(
+        &mut self,
+        device: &'a EthercrabSubDevicePreoperational<'a>,
+    ) -> Result<EncoderResolution, Error> {
+        let w = EtherCATSlaveWrapper::new(device);
+        let increments = w.read_sdo_u32(Reg::ENCODER_RESOLUTION, 1).await?;
+        let revolutions = w.read_sdo_u32(Reg::ENCODER_RESOLUTION, 2).await?;
+        if revolutions == 0 {
+            return Err(anyhow!(
+                "ENCODER_RESOLUTION sub-index 2 returned 0 revolutions"
+            ));
+        }
+        let res = EncoderResolution {
+            increments,
+            revolutions,
+        };
+        tracing::info!("Encoder resolution: {}/{} inc/rev", increments, revolutions);
+        self.encoder_resolution = Some(res);
+        Ok(res)
+    }
+
+    /// Write homing parameters to the drive over SDO.
+    pub async fn setup_homing<'a>(
+        &self,
+        device: &'a EthercrabSubDevicePreoperational<'a>,
+    ) -> Result<(), Error> {
+        let enc = self
+            .encoder_resolution
+            .ok_or_else(|| anyhow!("setup_homing called before encoder resolution was read"))?;
+        let w = EtherCATSlaveWrapper::new(device);
+
+        let mode_val: u8 = self.homing_config.homing_direction.mode_code();
+        w.write_sdo_u8(Reg::HOMING_MODE, 0, mode_val).await?;
+        w.write_sdo_u32(
+            Reg::HOMING_SPEED,
+            1,
+            enc.rps_to_inc_per_sec(self.homing_config.high_speed_rps),
+        )
+        .await?;
+        w.write_sdo_u32(
+            Reg::HOMING_SPEED,
+            2,
+            enc.rps_to_inc_per_sec(self.homing_config.slow_speed_rps),
+        )
+        .await?;
+        w.write_sdo_u32(
+            Reg::HOMING_ACC,
+            0,
+            enc.rps_to_inc_per_sec(self.homing_config.acceleration_rps_squared),
+        )
+        .await?;
+        w.write_sdo_i32(Reg::HOMING_OFFSET, 0, 0).await?;
+        tracing::info!("Setup Homing done");
+        Ok(())
+    }
+
+    /// Write SDO registers required to start a multi-turn encoder reset.
+    /// Must be called from async context when `state == State::ErrorEncoder`.
+    pub async fn start_encoder_multi_turn_reset<'a>(
+        &mut self,
+        device: &'a EthercrabSubDevicePreoperational<'a>,
+    ) -> Result<(), Error> {
+        let w = EtherCATSlaveWrapper::new(device);
+        w.write_sdo_u16(Reg::ENCODER_MULTI_TURN_DATA_CLEAR, 0, 0x31)
+            .await?;
+        w.write_sdo_u32(Reg::ENCODER_MULTI_TURN_DATA_CLEAR_TRIGGER, 1, 1 << 9)
+            .await?;
+        self.last_fault_reset_toggle
+            .get_or_insert_with(Instant::now);
+        Ok(())
+    }
+
+    /// Poll the clear-status register; returns `true` when reset is complete.
+    pub async fn encoder_multi_turn_reset_done<'a>(
+        &self,
+        device: &'a EthercrabSubDevicePreoperational<'a>,
+    ) -> Result<bool, Error> {
+        let w = EtherCATSlaveWrapper::new(device);
+        Ok(w.read_sdo_u16(Reg::ENCODER_MULTI_TURN_DATA_CLEAR, 0)
+            .await?
+            == 0)
+    }
+
+    /// Clear the encoder reset trigger registers after the reset cycle completes.
+    pub async fn finish_encoder_multi_turn_reset<'a>(
+        &mut self,
+        device: &'a EthercrabSubDevicePreoperational<'a>,
+    ) -> Result<(), Error> {
+        let w = EtherCATSlaveWrapper::new(device);
+        w.write_sdo_u32(Reg::ENCODER_MULTI_TURN_DATA_CLEAR_TRIGGER, 1, 0)
+            .await?;
+        self.last_fault_reset_toggle = None;
+        Ok(())
+    }
+}
+
+// Public motor API
+impl MinasA6BMotor {
+    pub fn get_position(&self) -> Option<f64> {
+        self.encoder_resolution
+            .map(|enc| enc.to_revolutions(self.txpdo.position_actual))
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.state.is_run()
+    }
+    pub fn is_homed(&self) -> bool {
+        self.homed
+    }
+    pub fn is_motion_done(&self) -> bool {
+        self.state == State::RunIdle
+    }
+    pub fn is_shut_down(&self) -> bool {
+        self.state == State::PreOpSwitchOnDisabled
+    }
+    pub fn has_error(&self) -> bool {
+        self.state.is_error()
+    }
+
+    pub fn enable(&mut self) {
+        // Symmetric with disable(): on a repeat call, just drive the state
+        // machine forward instead of re-issuing the command immediately.
+        if self.single_enable_flag {
+            self.poll();
+        } else {
+            self.single_enable_flag = true;
+            self.send_matching_enable_command();
+        }
+    }
+
+    pub fn disable(&mut self) {
+        if self.single_disable_flag {
+            self.poll();
+        } else {
+            self.single_disable_flag = true;
+            self.send_matching_disable_command();
+        }
+    }
+
+    pub async fn clear_alarm<'a>(
+        &self,
+        device: &'a EthercrabSubDevicePreoperational<'a>,
+    ) -> Result<(), Error> {
+        let w = EtherCATSlaveWrapper::new(device);
+        // Panasonic alarm clear object
+        w.write_sdo_u16(0x2280, 0, 0x0001).await?;
+        tracing::info!("Alarm clear sent");
+        Ok(())
+    }
+
+    pub fn quick_stop(&mut self) {
+        if self.state.is_run() {
+            self.apply_rxpdo(MinasA6BRxPdo {
+                control_word: Reg::CW_QUICK_STOP,
+                mode: self.current_motor_mode,
+                ..Default::default()
+            });
+            self.state = State::QuickStopWaiting;
+        }
+    }
+
+    pub fn leave_quick_stop(&mut self) {
+        if self.state != State::QuickStopReached {
+            return;
+        }
+        self.rxpdo = MinasA6BRxPdo {
+            control_word: 0b1111, // operation enabled
+            mode: self.current_motor_mode,
+            ..Default::default()
+        };
+        if self.status_run() {
+            self.state = State::RunIdle;
+        }
+    }
+
+    pub fn move_position(
+        &mut self,
+        position: PositionSpec,
+        transition: Option<PositionTransitionSpec>,
+    ) {
+        let Some(enc) = self.encoder_resolution else {
+            tracing::error!("move_position called before encoder resolution is known");
+            return;
+        };
+        tracing::debug!("Current position: {} inc", self.txpdo.position_actual);
+        let pdo = self.build_rxpdo_from_position_spec(&position, transition.as_ref(), enc);
+        self.motion_out_deque.push_back(pdo);
+        self.motion_transition = transition;
+    }
+
+    pub fn move_positions(
+        &mut self,
+        positions: Vec<PositionSpec>,
+        transition: Option<PositionTransitionSpec>,
+    ) {
+        let Some(enc) = self.encoder_resolution else {
+            tracing::error!("move_positions called before encoder resolution is known");
+            return;
+        };
+        for position in positions {
+            let pdo = self.build_rxpdo_from_position_spec(&position, transition.as_ref(), enc);
+            self.motion_out_deque.push_back(pdo);
+        }
+        self.motion_transition = transition;
+    }
+
+    pub fn abort_motion(&mut self) {
+        if let Some(pos) = self.get_position() {
+            self.motion_out_deque.clear();
+            self.move_position(
+                PositionSpec {
+                    n_revolutions: pos,
+                    is_absolute: true,
+                    speed_rps: 1.0,
+                    acceleration_rps2: 10.0,
+                    deceleration_rps2: 10.0,
+                },
+                None,
+            );
+            self.previous_motion_command = None;
+            self.current_motion_command = None;
+            self.motion_transition = None;
+            tracing::info!("Triggering immediate stop of ongoing motion...");
+        }
+    }
+
+    pub fn home(&mut self) {
+        if self.homing_issued.is_some() {
+            self.poll();
+        } else if matches!(self.state, State::Ready | State::RunIdle) {
+            tracing::info!("Triggering homing...");
+            self.current_motor_mode = MotorMode::HOMING;
+            self.mode_change_issued = Some(Instant::now());
+            self.state = State::HomingIdle;
+            self.write_keepalive_pdo();
+        } else {
+            self.enable();
+            self.needs_homing = true;
+        }
+    }
+
+    pub fn shut_down(&mut self) {
+        self.disable();
+    }
+}
+
+// State machine poll()
+impl MinasA6BMotor {
+    /// Called from `EthercatDevice::input()` once the TxPDO has been parsed.
+    pub fn poll(&mut self) {
+        match self.state {
+            // Re-classify from Unknown / post-reset
+            State::Unknown | State::ErrorResetToggled => {
+                self.classify_state();
+            }
+
+            // CiA 402 pre-op ladder (forward and backward)
+            State::PreOpNotRdyToSwitchOn => {
+                if self.single_enable_flag {
+                    self.send_matching_enable_command();
+                }
+                if self.status_switch_on_disabled() {
+                    self.state = State::PreOpSwitchOnDisabled;
+                }
+            }
+            State::PreOpSwitchOnDisabled => {
+                self.single_disable_flag = false;
+                if self.single_enable_flag {
+                    self.send_matching_enable_command();
+                }
+                if self.status_ready_to_switch_on() {
+                    self.state = State::PreOpReadyToSwitchOn;
+                }
+            }
+            State::PreOpReadyToSwitchOn => {
+                if self.single_enable_flag {
+                    self.send_matching_enable_command();
+                }
+                if self.single_disable_flag {
+                    self.send_matching_disable_command();
+                }
+                if self.status_ready() {
+                    self.state = State::Ready;
+                } else if self.status_switch_on_disabled() {
+                    self.state = State::PreOpSwitchOnDisabled;
+                }
+            }
+            State::Ready => {
+                if self.single_enable_flag {
+                    self.send_matching_enable_command();
+                }
+                if self.single_disable_flag {
+                    self.send_matching_disable_command();
+                }
+                if self.status_run() {
+                    self.single_enable_flag = false;
+                    self.state = State::RunIdle;
+                } else if self.status_ready_to_switch_on() {
+                    self.state = State::PreOpReadyToSwitchOn;
+                }
+            }
+
+            // Run states
+            State::RunIdle => {
+                self.single_enable_flag = false;
+                self.check_fault();
+                if self.needs_homing {
+                    self.current_motor_mode = MotorMode::HOMING;
+                    self.mode_change_issued = Some(Instant::now());
+                    self.write_keepalive_pdo();
+                    self.state = State::HomingIdle;
+                    return;
+                }
+                if self.single_disable_flag {
+                    self.send_matching_disable_command();
+                }
+                if self.status_ready() {
+                    self.state = State::Ready;
+                    return;
+                }
+                if !self.motion_out_deque.is_empty() {
+                    self.send_motion_command();
+                    self.state = State::RunSentMotionCommand;
+                }
+            }
+            State::RunSentMotionCommand => {
+                self.single_enable_flag = false;
+                self.check_fault();
+                if self.previous_motion_command.is_none() {
+                    self.make_set_point_ack();
+                    self.movement_delay = None;
+                    self.state = State::RunSentSetPointAck;
+                } else {
+                    self.state = State::RunWaitForSendingNextCommand;
+                }
+            }
+            State::RunWaitForSendingNextCommand => {
+                self.single_enable_flag = false;
+                self.check_fault();
+                if self.sending_next_command_granted() {
+                    self.make_set_point_ack();
+                    self.movement_delay = None;
+                    self.state = State::RunSentSetPointAck;
+                }
+            }
+            State::RunSentSetPointAck => {
+                self.single_enable_flag = false;
+                self.check_fault();
+                self.make_set_point_nack();
+                self.state = State::RunSentSetPointNack;
+            }
+            State::RunSentSetPointNack => {
+                self.single_enable_flag = false;
+                self.check_fault();
+                if self.status_set_point_nack() {
+                    self.state = State::RunExecuting;
+                }
+            }
+            State::RunExecuting => {
+                self.single_enable_flag = false;
+                self.check_fault();
+                if self.status_target_reached() && self.motion_out_deque.is_empty() {
+                    self.previous_motion_command = None;
+                    self.current_motion_command = None;
+                    self.motion_transition = None;
+                    self.state = State::RunIdle;
+                } else if !self.motion_out_deque.is_empty() {
+                    self.send_motion_command();
+                    self.state = State::RunSentMotionCommand;
+                }
+            }
+
+            // Homing
+            State::HomingIdle => {
+                let mode_ok = self.txpdo.mode_display == MotorMode::HOMING;
+                let settled = elapsed_at_least(&self.mode_change_issued, 3);
+                if !mode_ok || !settled {
+                    self.write_keepalive_pdo();
+                } else {
+                    // Set start-homing bit (bit 4)
+                    self.apply_rxpdo(MinasA6BRxPdo {
+                        control_word: Reg::CONTROL_WORD_ENABLE | 0x0010,
+                        mode: MotorMode::HOMING,
+                        ..Default::default()
+                    });
+                    self.homing_issued = Some(Instant::now());
+                    self.state = State::HomingSendingHomeCommand;
+                }
+            }
+            State::HomingSendingHomeCommand => {
+                if elapsed_at_least(&self.homing_issued, 100) {
+                    // Clear start-homing bit
+                    self.apply_rxpdo(MinasA6BRxPdo {
+                        control_word: Reg::CONTROL_WORD_ENABLE,
+                        mode: MotorMode::HOMING,
+                        ..Default::default()
+                    });
+                    self.state = State::HomingWaitForFinish;
+                }
+            }
+            State::HomingWaitForFinish => {
+                if self.status_homing_finished() {
+                    tracing::info!("Homing finished successfully!");
+                    self.homed = true;
+                    self.finish_homing();
+                } else if self.status_homing_failed() {
+                    tracing::error!("Homing error occurred!");
+                    self.homed = false;
+                    self.finish_homing();
+                }
+            }
+            State::HomingWaitForModeChange => {
+                let mode_ok = self.txpdo.mode_display == MotorMode::PP;
+                let settled = elapsed_at_least(&self.mode_change_issued, 3);
+                if mode_ok && settled {
+                    self.needs_homing = false;
+                    self.state = State::RunIdle;
+                }
+            }
+
+            // Quick-stop
+            State::QuickStopWaiting => {
+                if self.status_quick_stop() {
+                    self.state = State::QuickStopReached;
+                }
+            }
+            State::QuickStopReached => { /* stays here until leave_quick_stop() */ }
+
+            // Error / fault reset
+            State::ErrorAny => {
+                if self.error_code_is_encoder() {
+                    self.state = State::ErrorEncoder;
+                    // Owning task must call start_encoder_multi_turn_reset() async
+                    tracing::warn!(
+                        "Encoder multi-turn reset required — call start_encoder_multi_turn_reset() from async task"
+                    );
+                } else {
+                    self.apply_rxpdo(MinasA6BRxPdo {
+                        control_word: Reg::CW_FAULT_RESET,
+                        mode: self.current_motor_mode,
+                        ..Default::default()
+                    });
+                    self.last_fault_reset_toggle
+                        .get_or_insert_with(Instant::now);
+                    self.state = State::ErrorGeneric;
+                }
+            }
+            State::ErrorEncoder => {
+                // Async encoder-reset SDO steps are handled externally.
+                // When done, the owning task sets state back to ErrorGeneric
+                // via notify_encoder_reset_complete().
+            }
+            State::ErrorGeneric => {
+                // Self-arm if we arrived here without a timer set
+                if self.last_fault_reset_toggle.is_none() {
+                    self.last_fault_reset_toggle = Some(Instant::now());
+                }
+                if elapsed_at_least_secs(&self.last_fault_reset_toggle, 0.3) {
+                    self.apply_rxpdo(MinasA6BRxPdo {
+                        control_word: Reg::CONTROL_WORD_DISABLE,
+                        mode: self.current_motor_mode,
+                        ..Default::default()
+                    });
+                    self.last_fault_reset_toggle = None;
+                    self.state = State::ErrorResetToggled;
+                }
+            }
+            State::ErrorResetToggled => {
+                self.classify_state();
+            }
+        }
+    }
+
+    /// Called by the owning async task once `encoder_multi_turn_reset_done()` returns true.
+    pub fn notify_encoder_reset_complete(&mut self) {
+        self.last_fault_reset_toggle = None;
+        self.needs_homing = true;
+        self.homed = false; // encoder was corrupted homing must be repeated
+        tracing::warn!("Queuing motor homing as encoder was corrupted...");
+        // Re-enter generic fault reset to deassert the bit
+        self.apply_rxpdo(MinasA6BRxPdo {
+            control_word: Reg::CW_FAULT_RESET,
+            mode: self.current_motor_mode,
+            ..Default::default()
+        });
+        self.last_fault_reset_toggle = Some(Instant::now());
+        self.state = State::ErrorGeneric;
+    }
+
+    // Internal helpers
+    fn classify_state(&mut self) {
+        if self.status_fault() {
+            self.tell_about_error();
+            self.state = State::ErrorAny;
+        } else if self.status_not_ready_to_switch_on() {
+            self.state = State::PreOpNotRdyToSwitchOn;
+        } else if self.status_switch_on_disabled() {
+            self.state = State::PreOpSwitchOnDisabled;
+        } else if self.status_ready_to_switch_on() {
+            self.state = State::PreOpReadyToSwitchOn;
+        } else if self.status_ready() {
+            self.state = State::Ready;
+        } else if self.status_run() {
+            self.state = State::RunIdle;
+        }
+    }
+
+    fn check_fault(&mut self) {
+        if self.last_fault_reset_toggle.is_none()
+            && self.status_fault()
+            && self.state != State::ErrorAny
+        {
+            self.tell_about_error();
+            self.state = State::ErrorAny;
+        }
+    }
+
+    fn finish_homing(&mut self) {
+        self.homing_issued = None;
+        self.current_motor_mode = MotorMode::PP;
+        self.mode_change_issued = Some(Instant::now());
+        self.write_keepalive_pdo();
+        self.state = State::HomingWaitForModeChange;
+    }
+
+    fn apply_rxpdo(&mut self, pdo: MinasA6BRxPdo) {
+        self.rxpdo = pdo;
+    }
+
+    /// Write a keep-alive PDO (enable control word, current mode, zeroed motion fields).
+    fn write_keepalive_pdo(&mut self) {
+        self.rxpdo = MinasA6BRxPdo {
+            control_word: Reg::CONTROL_WORD_ENABLE,
+            mode: self.current_motor_mode,
+            ..Default::default()
+        };
+    }
+}
+
+// CiA 402 status word predicates
+impl MinasA6BMotor {
+    fn sw(&self) -> u16 {
+        self.txpdo.status_word
+    }
+
+    fn status_fault(&self) -> bool {
+        self.sw() & 0x4F == 0x08
+    }
+    fn status_not_ready_to_switch_on(&self) -> bool {
+        self.sw() & 0x4F == 0x00
+    }
+    fn status_switch_on_disabled(&self) -> bool {
+        self.sw() & 0x4F == 0x40
+    }
+    fn status_ready_to_switch_on(&self) -> bool {
+        self.sw() & 0x6F == 0x21
+    }
+    fn status_ready(&self) -> bool {
+        self.sw() & 0x6F == 0x23
+    }
+    fn status_run(&self) -> bool {
+        self.sw() & 0x6F == 0x27
+    }
+    fn status_quick_stop(&self) -> bool {
+        self.sw() & 0x6F == 0x07
+    }
+    fn status_homing_finished(&self) -> bool {
+        self.sw() & 0x1000 == 0x1000
+    }
+    fn status_homing_failed(&self) -> bool {
+        self.sw() & 0x2000 == 0x2000
+    }
+    fn status_set_point_nack(&self) -> bool {
+        self.sw() & 0x1000 == 0x0000
+    }
+    fn status_target_reached(&self) -> bool {
+        self.sw() & (1 << 10) != 0
+    }
+    fn error_code_is_encoder(&self) -> bool {
+        self.txpdo.error_code == 0xFF28
+    }
+}
+
+// CiA 402 command helpers
+impl MinasA6BMotor {
+    fn send_matching_enable_command(&mut self) {
+        tracing::debug!("Sending enable command for state {:?}", self.state);
+        let cw = match self.state {
+            State::PreOpSwitchOnDisabled | State::PreOpNotRdyToSwitchOn => {
+                Reg::CONTROL_WORD_READY_TO_SWITCH_ON
+            }
+            State::PreOpReadyToSwitchOn => Reg::CONTROL_WORD_SWITCH_ON,
+            State::Ready => Reg::CONTROL_WORD_ENABLE,
+            _ => return,
+        };
+        self.rxpdo.control_word = cw;
+        self.rxpdo.mode = self.current_motor_mode;
+    }
+
+    fn send_matching_disable_command(&mut self) {
+        tracing::debug!("Sending disable command for state {:?}", self.state);
+        let cw = match self.state {
+            State::Ready => Reg::CONTROL_WORD_READY_TO_SWITCH_ON,
+            State::PreOpReadyToSwitchOn => Reg::CONTROL_WORD_DISABLE,
+            _ => Reg::CONTROL_WORD_READY_TO_SWITCH_ON,
+        };
+        self.rxpdo.control_word = cw;
+        self.rxpdo.mode = self.current_motor_mode;
+    }
+
+    fn send_motion_command(&mut self) {
+        self.previous_motion_command = self.current_motion_command.take();
+        if let Some(cmd) = self.motion_out_deque.pop_front() {
+            tracing::info!(
+                "Sending motion command ({} left)...",
+                self.motion_out_deque.len()
+            );
+            self.rxpdo = cmd.clone();
+            self.current_motion_command = Some(cmd);
+        }
+    }
+
+    fn make_set_point_ack(&mut self) {
+        if let Some(ref cmd) = self.current_motion_command {
+            let mut updated = cmd.clone();
+            updated.control_word |= 0x0010; // set new-setpoint bit
+            tracing::info!(
+                "Starting motion command ({} left)...",
+                self.motion_out_deque.len()
+            );
+            self.rxpdo = updated;
+        }
+    }
+
+    fn make_set_point_nack(&mut self) {
+        self.rxpdo = MinasA6BRxPdo {
+            control_word: Reg::CONTROL_WORD_ENABLE,
+            mode: self.current_motor_mode,
+            ..Default::default()
+        };
+    }
+
+    fn tell_about_error(&self) {
+        tracing::error!(
+            "Motor fault! {} — trying auto-reset...",
+            interpret_error_code(self.txpdo.error_code)
+        );
+    }
+
+    fn build_rxpdo_from_position_spec(
+        &mut self,
+        spec: &PositionSpec,
+        transition: Option<&PositionTransitionSpec>,
+        enc: EncoderResolution,
+    ) -> MinasA6BRxPdo {
+        // Pass is_absolute so residue is handled correctly
+        let target_position = enc.to_increments(
+            spec.n_revolutions,
+            &mut self.pulse_residue,
+            spec.is_absolute,
+        );
+        let target_velocity = enc.rps_to_inc_per_sec(spec.speed_rps);
+        let target_accel = enc.rps_to_inc_per_sec(spec.acceleration_rps2);
+        let target_decel = enc.rps_to_inc_per_sec(spec.deceleration_rps2);
+
+        let mut control_word = Reg::CONTROL_WORD_ENABLE;
+        if !spec.is_absolute {
+            control_word |= 1 << 6;
+        }
+        if transition.map(|t| t.overlap).unwrap_or(false) {
+            control_word |= 1 << 5;
+        }
+
+        MinasA6BRxPdo {
+            control_word,
+            mode: MotorMode::PP,
+            target_position,
+            target_velocity,
+            target_accel,
+            target_decel,
+        }
+    }
+
+    fn sending_next_command_granted(&mut self) -> bool {
+        let Some(prev) = self.previous_motion_command.clone() else {
+            return true;
+        };
+        let Some(ref transition) = self.motion_transition.clone() else {
+            return self.status_target_reached();
+        };
+
+        if transition.overlap {
+            let offset = (self.txpdo.position_actual - prev.target_position).unsigned_abs() as f64;
+            let v = prev.target_velocity as f64;
+            let d = prev.target_decel as f64;
+            if d == 0.0 {
+                return false;
+            }
+            let vd = v / d;
+            let s_dec = vd * v / 2.0;
+            let remaining_ms = if offset >= s_dec {
+                1000.0 * (offset / v + vd / 2.0)
+            } else {
+                let disc = vd * vd - 2.0 * offset / d;
+                if disc < 0.0 {
+                    return false;
+                }
+                1000.0 * (vd - disc.sqrt())
+            };
+            tracing::debug!("remaining_motion_time_ms: {:.1}", remaining_ms);
+            remaining_ms <= transition.delay_ms
+        } else {
+            match self.movement_delay {
+                Some(t) => t.elapsed().as_millis() as f64 >= transition.delay_ms,
+                None => {
+                    if (self.txpdo.position_actual - prev.target_position).unsigned_abs() <= 1000 {
+                        self.movement_delay = Some(Instant::now());
+                    }
+                    false
+                }
+            }
+        }
+    }
+}
+
+// Small utilities
+fn elapsed_at_least(t: &Option<Instant>, millis: u64) -> bool {
+    t.map(|i| i.elapsed() >= Duration::from_millis(millis))
+        .unwrap_or(false)
+}
+
+fn elapsed_at_least_secs(t: &Option<Instant>, secs: f64) -> bool {
+    t.map(|i| i.elapsed().as_secs_f64() >= secs)
+        .unwrap_or(false)
+}
+
+fn interpret_error_code(code: u16) -> String {
+    match code {
+        0xFF28 => "Encoder multi-turn data error".to_string(),
+        c if c & 0xFF00 == 0xFF00 => format!("Error 0x{:02X} ({})", c & 0x00FF, c & 0x00FF),
+        c => format!("Error 0x{:04X} ({})", c, c),
+    }
+}
+
+impl MinasA6BDevice for MinasA6BMotor {
+    fn get_input(&self) -> Result<MinasA6BInput, Error> {
+        Ok(MinasA6BInput {
+            position: self.get_position(),
+            is_enabled: self.is_enabled(),
+            is_homed: self.is_homed(),
+            is_motion_done: self.is_motion_done(),
+            is_shut_down: self.is_shut_down(),
+            has_error: self.has_error(),
+            status_word: self.txpdo.status_word,
+            error_code: self.txpdo.error_code,
+            state: self.state,
+            mode_display: self.txpdo.mode_display,
+        })
+    }
+
+    fn get_output(&self) -> Result<MinasA6BOutput, Error> {
+        Ok(MinasA6BOutput {
+            control_word: self.rxpdo.control_word,
+            mode: self.rxpdo.mode,
+            target_position: self.rxpdo.target_position,
+            target_velocity: self.rxpdo.target_velocity,
+            target_accel: self.rxpdo.target_accel,
+            target_decel: self.rxpdo.target_decel,
+        })
+    }
+
+    fn enable(&mut self) -> Result<(), Error> {
+        MinasA6BMotor::enable(self);
+        Ok(())
+    }
+
+    fn disable(&mut self) -> Result<(), Error> {
+        MinasA6BMotor::disable(self);
+        Ok(())
+    }
+
+    fn quick_stop(&mut self) -> Result<(), Error> {
+        MinasA6BMotor::quick_stop(self);
+        Ok(())
+    }
+
+    fn leave_quick_stop(&mut self) -> Result<(), Error> {
+        MinasA6BMotor::leave_quick_stop(self);
+        Ok(())
+    }
+
+    fn move_position(
+        &mut self,
+        position: PositionSpec,
+        transition: Option<PositionTransitionSpec>,
+    ) -> Result<(), Error> {
+        self.move_position(position, transition);
+        Ok(())
+    }
+
+    fn move_positions(
+        &mut self,
+        positions: Vec<PositionSpec>,
+        transition: Option<PositionTransitionSpec>,
+    ) -> Result<(), Error> {
+        self.move_positions(positions, transition);
+        Ok(())
+    }
+
+    fn abort_motion(&mut self) -> Result<(), Error> {
+        self.abort_motion();
+        Ok(())
+    }
+
+    fn home(&mut self) -> Result<(), Error> {
+        self.home();
+        Ok(())
+    }
+}
+
+pub const MINAS_A6_VENDOR_ID: u32 = 0x66f;
+pub const MINAS_A6_PRODUCT_ID_A: u32 = 0x613c0006;
+pub const MINAS_A6_REVISION_A: u32 = 0x10000;
+pub const MINAS_A6_IDENTITY_A: SubDeviceIdentityTuple = (
+    MINAS_A6_VENDOR_ID,
+    MINAS_A6_PRODUCT_ID_A,
+    MINAS_A6_REVISION_A,
+);

--- a/ethercat_hal/src/devices/panasonic_modules/minas_a6.rs
+++ b/ethercat_hal/src/devices/panasonic_modules/minas_a6.rs
@@ -11,6 +11,7 @@ use crate::devices::{
 use crate::helpers::ethercrab_types::EthercrabSubDevicePreoperational;
 use crate::helpers::minas_a6_subdevice_wrapper::{EtherCATSlaveWrapper, PdoMapping};
 use crate::io::servo_velocity_minasa6::{MinasA6BDevice, MinasA6BInput, MinasA6BOutput};
+use crate::EncoderResolution;
 use anyhow::{Error, anyhow};
 use bitvec::field::BitField;
 use bitvec::prelude::{BitSlice, Lsb0};
@@ -286,12 +287,6 @@ impl Default for MotorHomingConfig {
             acceleration_rps_squared: 10.0,
         }
     }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct EncoderResolution {
-    pub increments: u32,
-    pub revolutions: u32,
 }
 
 impl EncoderResolution {

--- a/ethercat_hal/src/devices/panasonic_modules/minas_a6.rs
+++ b/ethercat_hal/src/devices/panasonic_modules/minas_a6.rs
@@ -760,6 +760,10 @@ impl MinasA6BMotor {
             .map(|enc| enc.to_revolutions(self.txpdo.position_actual))
     }
 
+    pub fn set_encoder_resolution(&mut self, resolution: EncoderResolution) {
+        self.encoder_resolution = Some(resolution);
+    }
+
     pub fn is_enabled(&self) -> bool {
         self.state.is_run()
     }

--- a/ethercat_hal/src/devices/panasonic_modules/minas_a6.rs
+++ b/ethercat_hal/src/devices/panasonic_modules/minas_a6.rs
@@ -4,7 +4,6 @@
 //!   - `input()`: unpack raw bytes from a `BitSlice` via `load_le` into a `TxPdo` struct.
 //!   - `output()`: pack a `RxPdo` struct into raw bytes and write them via `store_le`.
 
-use crate::coe::ConfigurableDevice;
 use crate::devices::{
     EthercatDevice, EthercatDeviceProcessing, EthercatDeviceUsed, EthercatDynamicPDO, Module,
     NewEthercatDevice, SubDeviceIdentityTuple,
@@ -28,7 +27,7 @@ impl Reg {
     pub const CONTROL_INPUT_SI_FUNCTION_ASSIGNMENT: u16 = 0x3400;
     pub const ENCODER_MULTI_TURN_DATA_CLEAR_TRIGGER: u16 = 0x4D00; // set from 0->1->0 after the register below has been set to 0x31
     pub const ENCODER_MULTI_TURN_DATA_CLEAR: u16 = 0x4D01; // set to 0x31 to clear the encoder data
-    pub const SET_MODE_OF_OPERATION: u16 = 0x6060; // set tot 1 for pp mode
+    pub const SET_MODE_OF_OPERATION: u16 = 0x6060; // set to 1 for pp mode
     pub const GET_MODE_OF_OPERATION: u16 = 0x6061;
     pub const POSITION_TARGET: u16 = 0x607A; // encoder-pulses
     pub const POSITION_ACTUAL: u16 = 0x6064; // encoder-pulses
@@ -36,9 +35,9 @@ impl Reg {
     pub const MAX_VELOCITY: u16 = 0x607F; // encoder-pulses/s
     pub const MAX_SPEED: u16 = 0x6080; // 1/min
     pub const TARGET_ACCELERATION: u16 = 0x6083; // encoder-pulses/s²
-    pub const TARGET_DECELERATION: u16 = 0x6084; // encoder-pulses/s
+    pub const TARGET_DECELERATION: u16 = 0x6084; // encoder-pulses/s²
     pub const ENCODER_RESOLUTION: u16 = 0x608F;
-    pub const MAX_ACCELERATION: u16 = 0x60C5; // encoder-pulses/s
+    pub const MAX_ACCELERATION: u16 = 0x60C5; // encoder-pulses/s²
 
     pub const ERROR_CODE: u16 = 0x603F;
     pub const MAX_TORQUE: u16 = 0x6072; // in 0.1%

--- a/ethercat_hal/src/devices/panasonic_modules/minas_a6_coe.rs
+++ b/ethercat_hal/src/devices/panasonic_modules/minas_a6_coe.rs
@@ -1,4 +1,4 @@
-use crate::devices::panasonic_modules::minas_a6::MotorHomingConfig;
+use crate::devices::panasonic_modules::minas_a6::{EncoderResolution, MotorHomingConfig};
 use crate::{
     ChannelRequest, ChannelRequests, ChannelResponse, EtherCATThreadChannel,
     EtherCATThreadResponseChannel,
@@ -19,12 +19,12 @@ impl Default for MinasA6BConfiguration {
     }
 }
 
-impl Configuration for MinasA6BConfiguration {
-    fn write_config(
+impl MinasA6BConfiguration {
+    pub fn write_config_and_get_resolution(
         &self,
         ecat_channel: EtherCATThreadChannel,
         device_address: u16,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<EncoderResolution, anyhow::Error> {
         let (response_tx, response_rx) = std::sync::mpsc::channel();
         ecat_channel.0.send(ChannelRequest {
             channel_request: ChannelRequests::ConfigureMinasA6B {
@@ -34,9 +34,20 @@ impl Configuration for MinasA6BConfiguration {
             response_channel: EtherCATThreadResponseChannel(response_tx),
         })?;
         match response_rx.recv()? {
-            ChannelResponse::ConfigureMinasA6BResponse(result) => result.map(|_| ()),
+            ChannelResponse::ConfigureMinasA6BResponse(result) => result,
             _ => Err(anyhow::anyhow!("Unexpected response from EtherCAT thread")),
         }
+    }
+}
+
+impl Configuration for MinasA6BConfiguration {
+    fn write_config(
+        &self,
+        ecat_channel: EtherCATThreadChannel,
+        device_address: u16,
+    ) -> Result<(), anyhow::Error> {
+        self.write_config_and_get_resolution(ecat_channel, device_address)
+            .map(|_| ())
     }
 }
 
@@ -47,8 +58,11 @@ impl ConfigurableDevice<MinasA6BConfiguration> for MinasA6BMotor {
         device_address: u16,
         config: &MinasA6BConfiguration,
     ) -> Result<(), anyhow::Error> {
-        config.write_config(ecat_channel, device_address)?;
+        let encoder_resolution =
+            config.write_config_and_get_resolution(ecat_channel, device_address)?;
+
         self.homing_config = config.homing_config.clone();
+        self.set_encoder_resolution(encoder_resolution);
         Ok(())
     }
 

--- a/ethercat_hal/src/devices/panasonic_modules/minas_a6_coe.rs
+++ b/ethercat_hal/src/devices/panasonic_modules/minas_a6_coe.rs
@@ -1,0 +1,60 @@
+use crate::devices::panasonic_modules::minas_a6::{EncoderResolution, MotorHomingConfig};
+use crate::{
+    ChannelRequest, ChannelRequests, ChannelResponse, EtherCATThreadChannel,
+    EtherCATThreadResponseChannel,
+    coe::{ConfigurableDevice, Configuration},
+    devices::panasonic_modules::minas_a6::MinasA6BMotor,
+};
+
+#[derive(Debug, Clone)]
+pub struct MinasA6BConfiguration {
+    pub homing_config: MotorHomingConfig,
+}
+
+impl Default for MinasA6BConfiguration {
+    fn default() -> Self {
+        Self {
+            homing_config: MotorHomingConfig::default(),
+        }
+    }
+}
+
+impl Configuration for MinasA6BConfiguration {
+    fn write_config(
+        &self,
+        ecat_channel: EtherCATThreadChannel,
+        device_address: u16,
+    ) -> Result<(), anyhow::Error> {
+        let (response_tx, response_rx) = std::sync::mpsc::channel();
+        ecat_channel.0.send(ChannelRequest {
+            channel_request: ChannelRequests::ConfigureMinasA6B {
+                device_address,
+                homing_config: self.homing_config.clone(),
+            },
+            response_channel: EtherCATThreadResponseChannel(response_tx),
+        })?;
+        match response_rx.recv()? {
+            ChannelResponse::ConfigureMinasA6BResponse(result) => result.map(|_| ()),
+            _ => Err(anyhow::anyhow!("Unexpected response from EtherCAT thread")),
+        }
+    }
+}
+
+impl ConfigurableDevice<MinasA6BConfiguration> for MinasA6BMotor {
+    fn write_config(
+        &mut self,
+        ecat_channel: EtherCATThreadChannel,
+        device_address: u16,
+        config: &MinasA6BConfiguration,
+    ) -> Result<(), anyhow::Error> {
+        config.write_config(ecat_channel, device_address)?;
+        self.homing_config = config.homing_config.clone();
+        Ok(())
+    }
+
+    fn get_config(&self) -> MinasA6BConfiguration {
+        MinasA6BConfiguration {
+            homing_config: self.homing_config.clone(),
+        }
+    }
+}

--- a/ethercat_hal/src/devices/panasonic_modules/minas_a6_coe.rs
+++ b/ethercat_hal/src/devices/panasonic_modules/minas_a6_coe.rs
@@ -1,4 +1,4 @@
-use crate::devices::panasonic_modules::minas_a6::{EncoderResolution, MotorHomingConfig};
+use crate::devices::panasonic_modules::minas_a6::MotorHomingConfig;
 use crate::{
     ChannelRequest, ChannelRequests, ChannelResponse, EtherCATThreadChannel,
     EtherCATThreadResponseChannel,

--- a/ethercat_hal/src/devices/panasonic_modules/minas_a6_coe.rs
+++ b/ethercat_hal/src/devices/panasonic_modules/minas_a6_coe.rs
@@ -1,4 +1,5 @@
-use crate::devices::panasonic_modules::minas_a6::{EncoderResolution, MotorHomingConfig};
+use crate::EncoderResolution;
+use crate::devices::panasonic_modules::minas_a6::MotorHomingConfig;
 use crate::{
     ChannelRequest, ChannelRequests, ChannelResponse, EtherCATThreadChannel,
     EtherCATThreadResponseChannel,

--- a/ethercat_hal/src/devices/panasonic_modules/mod.rs
+++ b/ethercat_hal/src/devices/panasonic_modules/mod.rs
@@ -1,0 +1,2 @@
+pub mod minas_a6;
+pub mod minas_a6_coe;

--- a/ethercat_hal/src/devices/wago_modules/ip20_ec_di8_do8.rs
+++ b/ethercat_hal/src/devices/wago_modules/ip20_ec_di8_do8.rs
@@ -6,10 +6,7 @@ use crate::devices::{
 use crate::{
     devices::{DynamicEthercatDevice, Module},
     helpers::ethercrab_types::EthercrabSubDevicePreoperational,
-    io::{
-        digital_input::DigitalInputDevice,
-        digital_output::{DigitalOutputDevice,},
-    },
+    io::{digital_input::DigitalInputDevice, digital_output::DigitalOutputDevice},
 };
 use anyhow::Error;
 use smol::lock::RwLock;
@@ -292,14 +289,13 @@ impl DigitalOutputDevice for IP20EcDi8Do8 {
             5 => self.rx_pdo.do6 = value,
             6 => self.rx_pdo.do7 = value,
             7 => self.rx_pdo.do8 = value,
-            _=>(),
+            _ => (),
         }
     }
 
     fn get_port_count(&self) -> usize {
         8
     }
-
 }
 
 impl IP20EcDi8Do8 {

--- a/ethercat_hal/src/devices/wago_modules/wago_750_1506.rs
+++ b/ethercat_hal/src/devices/wago_modules/wago_750_1506.rs
@@ -5,10 +5,7 @@ use crate::{
         DynamicEthercatDevice, EthercatDevice, EthercatDeviceProcessing, EthercatDeviceUsed,
         EthercatDynamicPDO, Module, NewEthercatDevice, SubDeviceProductTuple,
     },
-    io::{
-        digital_input::DigitalInputDevice,
-        digital_output::{DigitalOutputDevice},
-    },
+    io::{digital_input::DigitalInputDevice, digital_output::DigitalOutputDevice},
 };
 
 #[derive(Debug, Clone)]
@@ -131,7 +128,6 @@ impl DigitalOutputDevice for Wago750_1506 {
     fn get_port_count(&self) -> usize {
         8
     }
-
 }
 
 #[derive(Clone)]

--- a/ethercat_hal/src/devices/wago_modules/wago_750_455.rs
+++ b/ethercat_hal/src/devices/wago_modules/wago_750_455.rs
@@ -46,18 +46,18 @@ pub struct Wago750_455 {
 }
 
 impl AnalogInputDevice for Wago750_455 {
-    fn get_input(&self, port: usize ) ->  Result<AnalogInputInput,anyhow::Error> {
+    fn get_input(&self, port: usize) -> Result<AnalogInputInput, anyhow::Error> {
         let raw = match port {
             0 => self.tx_pdo.ai1,
             1 => self.tx_pdo.ai2,
             2 => self.tx_pdo.ai3,
             3 => self.tx_pdo.ai4,
-            _ => return Err( anyhow::anyhow!("port {} doesnt exist on Wago750_455",port)) ,
+            _ => return Err(anyhow::anyhow!("port {} doesnt exist on Wago750_455", port)),
         };
         let wiring_error = (raw & 0x0003) == 0x0003;
         let raw_value = (raw & 0x7FF0) as i16;
         let normalized = self.analog_input_range().raw_to_normalized(raw_value) as f32;
-        
+
         Ok(AnalogInputInput {
             normalized,
             wiring_error,

--- a/ethercat_hal/src/devices/wago_modules/wago_750_501.rs
+++ b/ethercat_hal/src/devices/wago_modules/wago_750_501.rs
@@ -3,7 +3,7 @@ use crate::devices::{
     SubDeviceProductTuple,
 };
 use crate::devices::{EthercatDeviceProcessing, NewEthercatDevice};
-use crate::io::digital_output::{DigitalOutputDevice};
+use crate::io::digital_output::DigitalOutputDevice;
 
 #[derive(Clone)]
 pub struct Wago750_501 {
@@ -49,14 +49,13 @@ impl DigitalOutputDevice for Wago750_501 {
                 // Modify the internal PDO representation
                 self.rxpdo.port2 = output_value;
             }
-            _=>(),
+            _ => (),
         }
     }
 
     fn get_port_count(&self) -> usize {
         2
     }
-
 }
 
 impl EthercatDeviceUsed for Wago750_501 {

--- a/ethercat_hal/src/devices/wago_modules/wago_750_530.rs
+++ b/ethercat_hal/src/devices/wago_modules/wago_750_530.rs
@@ -3,7 +3,7 @@ use crate::devices::{
     SubDeviceProductTuple,
 };
 use crate::devices::{EthercatDeviceProcessing, NewEthercatDevice};
-use crate::io::digital_output::{DigitalOutputDevice};
+use crate::io::digital_output::DigitalOutputDevice;
 
 #[derive(Clone)]
 pub struct Wago750_530 {
@@ -97,8 +97,6 @@ impl DigitalOutputDevice for Wago750_530 {
     fn get_port_count(&self) -> usize {
         8
     }
-
-
 }
 
 impl EthercatDeviceUsed for Wago750_530 {

--- a/ethercat_hal/src/devices/wago_modules/wago_750_652.rs
+++ b/ethercat_hal/src/devices/wago_modules/wago_750_652.rs
@@ -314,34 +314,26 @@ impl SerialInterfaceDevice for Wago750_652 {
         Needs to be called multiple times until it returns true, at which point it is ready to be used
     */
     fn serial_interface_initialize(&mut self, _port: usize) -> bool {
-                if !self.rx_pdo.control.init_request
-                    && !self.tx_pdo.status.init_ack
-                    && !self.started_init
-                {
-                    self.rx_pdo.control.init_request = true;
-                    self.started_init = true;
-                    return false;
-                }
+        if !self.rx_pdo.control.init_request && !self.tx_pdo.status.init_ack && !self.started_init {
+            self.rx_pdo.control.init_request = true;
+            self.started_init = true;
+            return false;
+        }
 
-                if self.rx_pdo.control.init_request && self.tx_pdo.status.init_ack {
-                    self.rx_pdo.control.init_request = false;
-                    return false;
-                }
+        if self.rx_pdo.control.init_request && self.tx_pdo.status.init_ack {
+            self.rx_pdo.control.init_request = false;
+            return false;
+        }
 
-                if !self.rx_pdo.control.init_request && self.tx_pdo.status.init_ack {
-                    return false;
-                }
+        if !self.rx_pdo.control.init_request && self.tx_pdo.status.init_ack {
+            return false;
+        }
 
-                if !self.rx_pdo.control.init_request
-                    && !self.tx_pdo.status.init_ack
-                    && self.started_init
-                {
-                    self.has_messages_last_toggle = self.tx_pdo.status.receive_request;
-                    return true;
-                }
-                false
-            
-        
+        if !self.rx_pdo.control.init_request && !self.tx_pdo.status.init_ack && self.started_init {
+            self.has_messages_last_toggle = self.tx_pdo.status.receive_request;
+            return true;
+        }
+        false
     }
 }
 

--- a/ethercat_hal/src/ethercat_helpers.rs
+++ b/ethercat_hal/src/ethercat_helpers.rs
@@ -209,13 +209,12 @@ impl EtherCATThreadChannel {
             response_channel: EtherCATThreadResponseChannel(tx),
         };
 
-
         let res = self.0.send(req);
         match res {
             Ok(_) => (),
             Err(e) => return Err(anyhow::anyhow!(e)),
         };
-        println!("sdo_write {:?}",res);
+        println!("sdo_write {:?}", res);
 
         let res = rx.recv_timeout(Duration::from_millis(500));
         let response: ChannelResponse = match res {

--- a/ethercat_hal/src/helpers/minas_a6_subdevice_wrapper.rs
+++ b/ethercat_hal/src/helpers/minas_a6_subdevice_wrapper.rs
@@ -1,0 +1,141 @@
+use crate::helpers::ethercrab_types::EthercrabSubDevicePreoperational;
+use anyhow::{Error, anyhow};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy)]
+pub struct PdoMapping {
+    pub object_index: u16,
+    pub sub_index: u8,
+    pub bit_length: u8,
+}
+
+impl PdoMapping {
+    pub fn to_u32(self) -> u32 {
+        ((self.object_index as u32) << 16)
+            | ((self.sub_index as u32) << 8)
+            | (self.bit_length as u32)
+    }
+}
+
+pub struct EtherCATSlaveWrapper<'a> {
+    device: &'a EthercrabSubDevicePreoperational<'a>,
+}
+
+impl<'a> EtherCATSlaveWrapper<'a> {
+    pub fn new(device: &'a EthercrabSubDevicePreoperational<'a>) -> Self {
+        Self { device }
+    }
+
+    // SDO write helpers
+
+    pub async fn write_sdo_u8(&self, index: u16, subindex: u8, value: u8) -> Result<(), Error> {
+        self.device
+            .sdo_write(index, subindex, value)
+            .await
+            .map_err(|e| anyhow!("sdo_write u8  [{:#06x}/{:#04x}]: {:?}", index, subindex, e))
+    }
+
+    pub async fn write_sdo_u16(&self, index: u16, subindex: u8, value: u16) -> Result<(), Error> {
+        self.device
+            .sdo_write(index, subindex, value)
+            .await
+            .map_err(|e| anyhow!("sdo_write u16 [{:#06x}/{:#04x}]: {:?}", index, subindex, e))
+    }
+
+    pub async fn write_sdo_u32(&self, index: u16, subindex: u8, value: u32) -> Result<(), Error> {
+        self.device
+            .sdo_write(index, subindex, value)
+            .await
+            .map_err(|e| anyhow!("sdo_write u32 [{:#06x}/{:#04x}]: {:?}", index, subindex, e))
+    }
+
+    pub async fn write_sdo_i16(&self, index: u16, subindex: u8, value: i16) -> Result<(), Error> {
+        self.device
+            .sdo_write(index, subindex, value)
+            .await
+            .map_err(|e| anyhow!("sdo_write i16 [{:#06x}/{:#04x}]: {:?}", index, subindex, e))
+    }
+
+    pub async fn write_sdo_i32(&self, index: u16, subindex: u8, value: i32) -> Result<(), Error> {
+        self.device
+            .sdo_write(index, subindex, value)
+            .await
+            .map_err(|e| anyhow!("sdo_write i32 [{:#06x}/{:#04x}]: {:?}", index, subindex, e))
+    }
+
+    // SDO read helpers
+    pub async fn read_sdo_u16(&self, index: u16, subindex: u8) -> Result<u16, Error> {
+        self.device
+            .sdo_read::<u16>(index, subindex)
+            .await
+            .map_err(|e| anyhow!("sdo_read  u16 [{:#06x}/{:#04x}]: {:?}", index, subindex, e))
+    }
+
+    pub async fn read_sdo_u32(&self, index: u16, subindex: u8) -> Result<u32, Error> {
+        self.device
+            .sdo_read::<u32>(index, subindex)
+            .await
+            .map_err(|e| anyhow!("sdo_read  u32 [{:#06x}/{:#04x}]: {:?}", index, subindex, e))
+    }
+
+    // PDO assignment / mapping
+
+    pub async fn assign_pdos(&self, assign_index: u16, pdo_indices: &[u16]) -> Result<(), Error> {
+        self.write_sdo_u8(assign_index, 0x00, 0).await?;
+        for (i, &pdo_index) in pdo_indices.iter().enumerate() {
+            self.write_sdo_u16(assign_index, (i + 1) as u8, pdo_index)
+                .await?;
+        }
+        self.write_sdo_u8(assign_index, 0x00, pdo_indices.len() as u8)
+            .await
+    }
+
+    pub async fn configure_pdo_mapping(
+        &self,
+        map_index: u16,
+        mappings: &[PdoMapping],
+    ) -> Result<(), Error> {
+        self.write_sdo_u8(map_index, 0x00, 0).await?;
+        for (i, mapping) in mappings.iter().enumerate() {
+            self.write_sdo_u32(map_index, (i + 1) as u8, mapping.to_u32())
+                .await?;
+        }
+        self.write_sdo_u8(map_index, 0x00, mappings.len() as u8)
+            .await
+    }
+}
+
+pub async fn wait_status<F>(
+    mut input_fn: F,
+    status_word_byte_offset: usize,
+    expected_status: u16,
+    status_description: &str,
+    status_mask: u16,
+    timeout: Duration,
+) -> Result<(), Error>
+where
+    F: FnMut() -> Vec<u8>,
+{
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        let raw = input_fn();
+        let end = status_word_byte_offset + 2;
+
+        if end <= raw.len() {
+            let status = u16::from_le_bytes([
+                raw[status_word_byte_offset],
+                raw[status_word_byte_offset + 1],
+            ]);
+            if (status & status_mask) == expected_status {
+                return Ok(());
+            }
+        }
+
+        if Instant::now() >= deadline {
+            return Err(anyhow!("Timeout waiting for {}", status_description));
+        }
+
+        smol::Timer::after(Duration::from_millis(2)).await;
+    }
+}

--- a/ethercat_hal/src/helpers/mod.rs
+++ b/ethercat_hal/src/helpers/mod.rs
@@ -1,6 +1,7 @@
 pub mod counter_wrapper_u16_i128;
 pub mod el70xx_velocity_converter;
 pub mod ethercrab_types;
+pub mod minas_a6_subdevice_wrapper;
 pub mod signing_converter_u16;
 
 use ethercrab::{SubDevice, SubDeviceRef};

--- a/ethercat_hal/src/io/analog_input/mod.rs
+++ b/ethercat_hal/src/io/analog_input/mod.rs
@@ -1,7 +1,6 @@
 use physical::{AnalogInputRange, AnalogInputValue};
 pub mod physical;
 
-
 #[derive(Debug, Clone)]
 pub struct AnalogInputInput {
     /// from -1.0 to 1.0
@@ -18,7 +17,7 @@ impl AnalogInputInput {
 }
 
 pub trait AnalogInputDevice {
-    fn get_input(&self, port: usize) -> Result<AnalogInputInput,anyhow::Error>;
+    fn get_input(&self, port: usize) -> Result<AnalogInputInput, anyhow::Error>;
     fn analog_input_range(&self) -> AnalogInputRange;
     fn get_port_count(&self) -> usize;
 }

--- a/ethercat_hal/src/io/analog_output.rs
+++ b/ethercat_hal/src/io/analog_output.rs
@@ -13,7 +13,7 @@ impl From<AnalogOutputOutput> for f32 {
     }
 }
 
-pub trait AnalogOutputDevice  {
+pub trait AnalogOutputDevice {
     fn set_output(&mut self, port: usize, value: AnalogOutputOutput);
     fn get_port_count(&self) -> usize;
 }

--- a/ethercat_hal/src/io/digital_output.rs
+++ b/ethercat_hal/src/io/digital_output.rs
@@ -1,5 +1,5 @@
 use crate::devices::EthercatDevice;
-pub trait DigitalOutputDevice : EthercatDevice {
-    fn set_output(&mut self, port: usize, value: bool);    
+pub trait DigitalOutputDevice: EthercatDevice {
+    fn set_output(&mut self, port: usize, value: bool);
     fn get_port_count(&self) -> usize;
 }

--- a/ethercat_hal/src/io/encoder_input.rs
+++ b/ethercat_hal/src/io/encoder_input.rs
@@ -15,8 +15,7 @@ pub struct EncoderInputPeriod {
     pub value: u32,
 }
 
-pub trait EncoderInputDevice : EthercatDevice
-{
+pub trait EncoderInputDevice: EthercatDevice {
     fn get_counter_value(&self, port: usize) -> Result<EncoderInputCounter, anyhow::Error>;
     fn get_frequency(&self, port: usize) -> Result<Option<EncoderInputFrequency>, anyhow::Error>;
     fn get_period(&self, port: usize) -> Result<Option<EncoderInputPeriod>, anyhow::Error>;

--- a/ethercat_hal/src/io/mod.rs
+++ b/ethercat_hal/src/io/mod.rs
@@ -5,5 +5,6 @@ pub mod digital_output;
 pub mod encoder_input;
 pub mod pulse_train_output;
 pub mod serial_interface;
+pub mod servo_velocity_minasa6;
 pub mod stepper_velocity_el70x1;
 pub mod temperature_input;

--- a/ethercat_hal/src/io/serial_interface.rs
+++ b/ethercat_hal/src/io/serial_interface.rs
@@ -1,7 +1,6 @@
 use anyhow::Error;
 
-pub trait SerialInterfaceDevice
-{
+pub trait SerialInterfaceDevice {
     fn serial_interface_read_message(&mut self, port: usize) -> Option<Vec<u8>>;
     fn serial_interface_write_message(
         &mut self,

--- a/ethercat_hal/src/io/servo_velocity_minasa6.rs
+++ b/ethercat_hal/src/io/servo_velocity_minasa6.rs
@@ -1,0 +1,109 @@
+use crate::devices::{
+    EthercatDevice,
+    panasonic_modules::minas_a6::{PositionSpec, PositionTransitionSpec, State},
+};
+use anyhow::Error;
+
+/// Snapshot of the motor's current status (derived from TxPDO + internal state machine).
+#[derive(Debug, Clone)]
+pub struct MinasA6BInput {
+    /// Current motor position in revolutions. `None` if encoder resolution has not been read yet.
+    pub position: Option<f64>,
+
+    /// Whether the motor's state machine is in a `Run*` state.
+    pub is_enabled: bool,
+
+    /// Whether homing has been completed successfully.
+    pub is_homed: bool,
+
+    /// Whether the motor has finished all queued motion commands (`RunIdle`).
+    pub is_motion_done: bool,
+
+    /// Whether the motor is fully shut down (`PreOpSwitchOnDisabled`).
+    pub is_shut_down: bool,
+
+    /// Whether the state machine is in any error state.
+    pub has_error: bool,
+
+    /// Raw CiA 402 status word from the drive.
+    pub status_word: u16,
+
+    /// Raw error code from the drive (e.g. `0xFF28` = encoder multi-turn error).
+    pub error_code: u16,
+
+    /// Current internal state machine state.
+    pub state: State,
+
+    /// Mode currently displayed by the drive (PP = 1, Homing = 6).
+    pub mode_display: u8,
+}
+
+/// Snapshot of the last RxPDO values being sent to the drive.
+#[derive(Debug, Clone)]
+pub struct MinasA6BOutput {
+    /// CiA 402 control word currently being written to the drive.
+    pub control_word: u16,
+
+    /// Operation mode currently requested (PP = 1, Homing = 6).
+    pub mode: u8,
+
+    /// Target position in encoder increments.
+    pub target_position: i32,
+
+    /// Target velocity in encoder increments/s.
+    pub target_velocity: u32,
+
+    /// Target acceleration in encoder increments/s².
+    pub target_accel: u32,
+
+    /// Target deceleration in encoder increments/s².
+    pub target_decel: u32,
+}
+
+pub trait MinasA6BDevice: EthercatDevice {
+    fn get_input(&self) -> Result<MinasA6BInput, Error>;
+    fn get_output(&self) -> Result<MinasA6BOutput, Error>;
+
+    fn get_position(&self) -> Option<f64> {
+        self.get_input().ok().and_then(|i| i.position)
+    }
+    fn is_enabled(&self) -> bool {
+        self.get_input().map(|i| i.is_enabled).unwrap_or(false)
+    }
+    fn is_homed(&self) -> bool {
+        self.get_input().map(|i| i.is_homed).unwrap_or(false)
+    }
+    fn is_motion_done(&self) -> bool {
+        self.get_input().map(|i| i.is_motion_done).unwrap_or(false)
+    }
+    fn is_shut_down(&self) -> bool {
+        self.get_input().map(|i| i.is_shut_down).unwrap_or(false)
+    }
+    fn has_error(&self) -> bool {
+        self.get_input().map(|i| i.has_error).unwrap_or(false)
+    }
+
+    fn enable(&mut self) -> Result<(), Error>;
+    fn disable(&mut self) -> Result<(), Error>;
+    fn shut_down(&mut self) -> Result<(), Error> {
+        self.disable()
+    }
+
+    fn quick_stop(&mut self) -> Result<(), Error>;
+    fn leave_quick_stop(&mut self) -> Result<(), Error>;
+
+    fn move_position(
+        &mut self,
+        position: PositionSpec,
+        transition: Option<PositionTransitionSpec>,
+    ) -> Result<(), Error>;
+
+    fn move_positions(
+        &mut self,
+        positions: Vec<PositionSpec>,
+        transition: Option<PositionTransitionSpec>,
+    ) -> Result<(), Error>;
+
+    fn abort_motion(&mut self) -> Result<(), Error>;
+    fn home(&mut self) -> Result<(), Error>;
+}

--- a/ethercat_hal/src/io/stepper_velocity_el70x1.rs
+++ b/ethercat_hal/src/io/stepper_velocity_el70x1.rs
@@ -1,6 +1,6 @@
+use super::analog_input::{AnalogInputInput, physical::AnalogInputRange};
 use crate::{devices::EthercatDevice, helpers::el70xx_velocity_converter::EL70x1VelocityConverter};
 use anyhow::Error;
-use super::analog_input::{AnalogInputInput, physical::AnalogInputRange};
 
 #[derive(Debug, Clone)]
 pub struct StepperVelocityEL70x1Input {
@@ -47,14 +47,13 @@ pub struct StepperVelocityEL70x1Output {
     pub set_counter: Option<i128>,
 }
 
-pub trait StepperVelocityEL70x1Device : EthercatDevice
-{
+pub trait StepperVelocityEL70x1Device: EthercatDevice {
     fn set_output(&mut self, port: usize, value: StepperVelocityEL70x1Output) -> Result<(), Error>;
     fn get_input(&self, port: usize) -> Result<StepperVelocityEL70x1Input, Error>;
     fn get_output(&self, port: usize) -> Result<StepperVelocityEL70x1Output, Error>;
     fn get_speed_range(&self, port: usize) -> crate::shared_config::el70x1::EL70x1SpeedRange;
     /// Set the speed in steps per second
-    fn set_speed(&mut self, port : usize, steps_per_second: f64) -> Result<(), Error> {
+    fn set_speed(&mut self, port: usize, steps_per_second: f64) -> Result<(), Error> {
         // Get current state to preserve other output values
         let mut output = self.get_output(port).unwrap();
 
@@ -66,11 +65,11 @@ pub trait StepperVelocityEL70x1Device : EthercatDevice
         output.velocity = velocity;
 
         // Write to device
-        self.set_output(port,output)
+        self.set_output(port, output)
     }
 
     /// Get the speed in steps per second
-    fn get_speed(&self, port : usize) -> i32 {
+    fn get_speed(&self, port: usize) -> i32 {
         let output = self.get_output(port).unwrap();
         let speed_range = self.get_speed_range(port);
         let converter = EL70x1VelocityConverter::new(&speed_range);
@@ -78,22 +77,19 @@ pub trait StepperVelocityEL70x1Device : EthercatDevice
     }
 
     fn get_port_count(&self) -> usize;
-    fn is_enabled(&self,port : usize) -> bool;
-    fn set_enabled(&mut self,port : usize, enabled: bool) {        
+    fn is_enabled(&self, port: usize) -> bool;
+    fn set_enabled(&mut self, port: usize, enabled: bool) {
         let mut output = self.get_output(port).unwrap();
         output.enable = enabled;
         self.set_output(port, output);
     }
-    fn get_position(&self,port : usize) -> i128;
-    fn set_position(&mut self,port : usize, position: i128);
+    fn get_position(&self, port: usize) -> i128;
+    fn set_position(&mut self, port: usize, position: i128);
 
     fn get_digital_input(&self, port: usize) -> Result<bool, anyhow::Error>;
     fn get_digital_in_port_count(&self) -> usize;
-    
-    fn get_analog_input(&self, port: usize) -> Result<AnalogInputInput,anyhow::Error>;
+
+    fn get_analog_input(&self, port: usize) -> Result<AnalogInputInput, anyhow::Error>;
     fn get_analog_port_count(&self) -> usize;
     fn analog_input_range(&self) -> Option<AnalogInputRange>;
-    
-
-
 }

--- a/ethercat_hal/src/io/temperature_input.rs
+++ b/ethercat_hal/src/io/temperature_input.rs
@@ -1,5 +1,5 @@
 use crate::{devices::EthercatDevice, pdo::basic::Limit};
-use std::{fmt};
+use std::fmt;
 
 /// Temperature Input (TI) device
 ///
@@ -21,12 +21,12 @@ pub enum TemperatureInputError {
 }
 
 #[derive(Debug, Clone)]
-pub struct TemperatureInputInput {    
-    pub temperature: f32,    
-    pub undervoltage: bool,    
-    pub overvoltage: bool,    
+pub struct TemperatureInputInput {
+    pub temperature: f32,
+    pub undervoltage: bool,
+    pub overvoltage: bool,
     pub limit1: Limit,
-    pub limit2: Limit,    
+    pub limit2: Limit,
     pub error: bool,
     /// if the TxPdo state is valid
     pub txpdo_state: bool,
@@ -34,7 +34,7 @@ pub struct TemperatureInputInput {
     pub txpdo_toggle: bool,
 }
 
-pub trait TemperatureInputDevice : EthercatDevice {
-    fn get_input(&self, port: usize) -> Result<TemperatureInputInput,anyhow::Error>;
+pub trait TemperatureInputDevice: EthercatDevice {
+    fn get_input(&self, port: usize) -> Result<TemperatureInputInput, anyhow::Error>;
     fn get_port_count(&self) -> usize;
 }

--- a/ethercat_hal/src/lib.rs
+++ b/ethercat_hal/src/lib.rs
@@ -10,7 +10,6 @@ pub mod shared_config;
 //#[cfg(feature = "legacy_code")]
 pub mod machine_ident_read;
 use crate::controller::EtherCATController;
-use crate::devices::panasonic_modules::minas_a6::EncoderResolution;
 use controller::{
     EtherCATAppHandle, MockConsumer, MockProducer, TripleBufConsumer, TripleBufProducer,
 };
@@ -148,6 +147,13 @@ pub struct SdoReadRequest {
 
 // LEGACY CODE HIDE BEHIND FLAG
 pub struct MachineIdent {}
+
+/// Driver-agnostic encoder resolution returned from device configuration.
+#[derive(Clone, Copy, Debug)]
+pub struct EncoderResolution {
+    pub increments: u32,
+    pub revolutions: u32,
+}
 
 #[derive(Debug)]
 pub enum ChannelResponse {

--- a/ethercat_hal/src/lib.rs
+++ b/ethercat_hal/src/lib.rs
@@ -10,7 +10,10 @@ pub mod shared_config;
 //#[cfg(feature = "legacy_code")]
 pub mod machine_ident_read;
 use crate::controller::EtherCATController;
-use controller::{EtherCATAppHandle, MockConsumer, MockProducer, TripleBufConsumer, TripleBufProducer};
+use crate::devices::panasonic_modules::minas_a6::EncoderResolution;
+use controller::{
+    EtherCATAppHandle, MockConsumer, MockProducer, TripleBufConsumer, TripleBufProducer,
+};
 use ethercrab::PduStorage;
 use machine_ident_read::MachineDeviceInfo;
 use std::sync::mpsc;
@@ -44,16 +47,20 @@ pub struct EtherCATThreadResponseChannel(pub Sender<ChannelResponse>);
 pub use controller::Consumer;
 pub use controller::Producer;
 
-pub struct EtherCATControl<C,P> where C : Consumer, P: Producer {
-    pub controller: Arc<EtherCATController<C,P>>,
+pub struct EtherCATControl<C, P>
+where
+    C: Consumer,
+    P: Producer,
+{
+    pub controller: Arc<EtherCATController<C, P>>,
     pub channel: EtherCATThreadChannel,
-    pub app_handle: EtherCATAppHandle<C,P>,
+    pub app_handle: EtherCATAppHandle<C, P>,
     pub join_handle: Option<JoinHandle<()>>,
 }
 
 pub type StandardEtherCATAppHandle = EtherCATAppHandle<TripleBufConsumer, TripleBufProducer>;
-pub type MockEtherCATAppHandle = EtherCATAppHandle<MockConsumer,MockProducer>;
-pub type StandardEtherCATController = EtherCATController<TripleBufConsumer,TripleBufProducer>;
+pub type MockEtherCATAppHandle = EtherCATAppHandle<MockConsumer, MockProducer>;
+pub type StandardEtherCATController = EtherCATController<TripleBufConsumer, TripleBufProducer>;
 
 /*Metadata for a Subdevice Contains start and end of the given subdevices pdu*/
 #[derive(Clone, Copy, Debug)]
@@ -154,6 +161,7 @@ pub enum ChannelResponse {
     ChangeState(Result<(), anyhow::Error>),
     MachineDeviceInfoResponse(Result<Vec<MachineDeviceInfo>, anyhow::Error>),
     EnableDCSync0Response(Result<(), anyhow::Error>),
+    ConfigureMinasA6BResponse(Result<EncoderResolution, anyhow::Error>),
 }
 
 #[derive(Debug)]
@@ -166,6 +174,10 @@ pub enum ChannelRequests {
     Shutdown(),
     // Legacy code, only usable when feature enable_legacy_code is set
     ReadMachineIdent(),
+    ConfigureMinasA6B {
+        device_address: u16,
+        homing_config: crate::devices::panasonic_modules::minas_a6::MotorHomingConfig,
+    },
 }
 
 pub struct ChannelRequest {
@@ -174,19 +186,29 @@ pub struct ChannelRequest {
 }
 
 pub fn send_response(response_channel: EtherCATThreadResponseChannel, response: ChannelResponse) {
-    let _res = response_channel.0.send(response);    
+    let _res = response_channel.0.send(response);
 }
 
-
-pub fn init_ethercat_mock(faked_subdevices : Vec<MetaSubdevice>, machine_infos : Option<Vec<MachineDeviceInfo>>) -> EtherCATControl<MockConsumer,MockProducer> {
+pub fn init_ethercat_mock(
+    faked_subdevices: Vec<MetaSubdevice>,
+    machine_infos: Option<Vec<MachineDeviceInfo>>,
+) -> EtherCATControl<MockConsumer, MockProducer> {
     let (tx, rx) = mpsc::channel();
-    let mock_producer = [0u8;ETHERCAT_TX_RX_SIZE];
-    let mock_consumer = [0u8;ETHERCAT_TX_RX_SIZE];
-    let producer = MockProducer{ buffer: mock_producer };
-    let consumer = MockConsumer{ buffer: mock_consumer };
+    let mock_producer = [0u8; ETHERCAT_TX_RX_SIZE];
+    let mock_consumer = [0u8; ETHERCAT_TX_RX_SIZE];
+    let producer = MockProducer {
+        buffer: mock_producer,
+    };
+    let consumer = MockConsumer {
+        buffer: mock_consumer,
+    };
 
-    let producer_c = MockProducer{ buffer: [0u8;ETHERCAT_TX_RX_SIZE] };
-    let consumer_c = MockConsumer{ buffer: [0u8;ETHERCAT_TX_RX_SIZE] };
+    let producer_c = MockProducer {
+        buffer: [0u8; ETHERCAT_TX_RX_SIZE],
+    };
+    let consumer_c = MockConsumer {
+        buffer: [0u8; ETHERCAT_TX_RX_SIZE],
+    };
 
     let channel: EtherCATThreadChannel = EtherCATThreadChannel(tx);
     let app_handle = EtherCATAppHandle {
@@ -194,23 +216,25 @@ pub fn init_ethercat_mock(faked_subdevices : Vec<MetaSubdevice>, machine_infos :
         output_producer: producer,
     };
 
-    let mut controller = EtherCATController::new(
-        producer_c,
-        consumer_c,
-        rx,
-        None,
-    );
+    let mut controller = EtherCATController::new(producer_c, consumer_c, rx, None);
 
-    controller.subdevice_count = faked_subdevices.len();    
+    controller.subdevice_count = faked_subdevices.len();
     for i in 0..faked_subdevices.len() {
         controller.subdevices[i] = faked_subdevices[i];
     }
 
     let controller = Arc::new(controller);
-    return EtherCATControl { controller, channel, app_handle, join_handle: None }
+    return EtherCATControl {
+        controller,
+        channel,
+        app_handle,
+        join_handle: None,
+    };
 }
 
-pub fn init_ethercat(interface_name: &str) -> EtherCATControl<TripleBufConsumer,TripleBufProducer> {
+pub fn init_ethercat(
+    interface_name: &str,
+) -> EtherCATControl<TripleBufConsumer, TripleBufProducer> {
     let (tx, rx) = mpsc::channel();
 
     let (input_producer, input_consumer) =
@@ -219,16 +243,19 @@ pub fn init_ethercat(interface_name: &str) -> EtherCATControl<TripleBufConsumer,
         triple_buffer::triple_buffer(&[0u8; ETHERCAT_TX_RX_SIZE]);
 
     let controller = Arc::new(EtherCATController::new(
-        TripleBufProducer{output_producer:  input_producer},
-        TripleBufConsumer{input_consumer: output_consumer } ,
+        TripleBufProducer {
+            output_producer: input_producer,
+        },
+        TripleBufConsumer {
+            input_consumer: output_consumer,
+        },
         rx,
         Some(interface_name.to_string()),
     ));
 
     let app_handle = EtherCATAppHandle {
-        input_consumer: TripleBufConsumer{ input_consumer },
-        output_producer: TripleBufProducer { output_producer } ,
- 
+        input_consumer: TripleBufConsumer { input_consumer },
+        output_producer: TripleBufProducer { output_producer },
     };
 
     let channel: EtherCATThreadChannel = EtherCATThreadChannel(tx);
@@ -239,7 +266,8 @@ pub fn init_ethercat(interface_name: &str) -> EtherCATControl<TripleBufConsumer,
         .name("EthercatStateMachine".into())
         .spawn(move || {
             // We need &mut self for the state machine.
-            let ptr = Arc::as_ptr(&controller_for_thread) as *mut EtherCATController<TripleBufConsumer,TripleBufProducer>;
+            let ptr = Arc::as_ptr(&controller_for_thread)
+                as *mut EtherCATController<TripleBufConsumer, TripleBufProducer>;
             unsafe {
                 (&mut *ptr).ethercat_state_machine();
             }

--- a/modbus/examples/ex_02.rs
+++ b/modbus/examples/ex_02.rs
@@ -18,6 +18,7 @@ pub async fn main() {
         let tty_path = "/dev/ttyUSB0";
         let slave = Slave(0x17);
         let builder = tokio_serial::new(tty_path, 38400);
+        let mgr = ExampleDeviceManager::new(tx);
 
         let port = SerialStream::open(&builder).unwrap();
         let ctx = rtu::attach_slave(port, slave);

--- a/modbus/src/clients/example_client.rs
+++ b/modbus/src/clients/example_client.rs
@@ -34,10 +34,10 @@ impl ExampleClient {
                     let res = tx.send(result).await;
                     match res {
                         Ok(r) => r,
-                        Err(e) => println!("error:{:?}",e),
+                        Err(e) => println!("error:{:?}", e),
                     }
-                },
-                Err(e) => println!("ex client error {:?}",e),
+                }
+                Err(e) => println!("ex client error {:?}", e),
             }
         }
     }

--- a/modbus/src/devices/us_3202510/mod.rs
+++ b/modbus/src/devices/us_3202510/mod.rs
@@ -225,8 +225,8 @@ impl<S: Scheduler + 'static> Device<S> for VfdDevice<S> {
         }
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {        
-        self    
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {

--- a/modbus/src/lib.rs
+++ b/modbus/src/lib.rs
@@ -2,19 +2,18 @@ pub mod clients;
 pub mod devices;
 pub mod managers;
 
-use std::{any::Any};
+use std::any::Any;
 
 use clients::example_client::{ExampleClient, RequestMessage};
 use tokio::sync::mpsc::Receiver;
-use tokio_modbus::{Slave, client::rtu};
 pub use tokio_modbus as protocol;
+use tokio_modbus::{Slave, client::rtu};
 use tokio_serial::SerialStream;
 
 pub type Request = protocol::Request<'static>;
 pub type Response = protocol::Response;
 pub type ExceptionCode = protocol::ExceptionCode;
 pub type FunctionCode = protocol::FunctionCode;
-
 
 pub fn start_modbus_async_task(
     tty_path: String,

--- a/modbus/src/managers/example_manager.rs
+++ b/modbus/src/managers/example_manager.rs
@@ -5,19 +5,26 @@ use std::{
 };
 
 use tokio::sync::{
-    mpsc::{self, Sender,Receiver},
+    mpsc::{self, Receiver, Sender},
     oneshot,
 };
 use tokio_modbus::{ExceptionCode, Response};
 
 use crate::{Device, Priority, Scheduler};
 
-use crate::clients::example_client::{RequestMessage};
+use crate::clients::example_client::RequestMessage;
 
 pub struct ExampleDeviceManager {
     tx: mpsc::Sender<RequestMessage>,
 
-    devices: HashMap<u8, (Sender<Result<Response,ExceptionCode>>,Receiver<Result<Response,ExceptionCode>>, Rc<RefCell<dyn Device<ExampleScheduler>>>) >,
+    devices: HashMap<
+        u8,
+        (
+            Sender<Result<Response, ExceptionCode>>,
+            Receiver<Result<Response, ExceptionCode>>,
+            Rc<RefCell<dyn Device<ExampleScheduler>>>,
+        ),
+    >,
     scheduled_devices: VecDeque<u8>,
     pending_response: Option<u8>,
 }
@@ -60,8 +67,11 @@ impl ExampleDeviceManager {
         };
 
         let device = Rc::new(RefCell::new(D::new(scheduler)));
-        let (tx,rx) = tokio::sync::mpsc::channel(2);
-        mgr_rc.borrow_mut().devices.insert(slave_id,( tx,rx,device.clone()) );
+        let (tx, rx) = tokio::sync::mpsc::channel(2);
+        mgr_rc
+            .borrow_mut()
+            .devices
+            .insert(slave_id, (tx, rx, device.clone()));
         device
     }
 
@@ -98,7 +108,6 @@ impl ExampleDeviceManager {
             let device = self.devices.get(&id).unwrap();
 
             let (request, has_more) = device.2.borrow_mut().next_request().unwrap();
-
 
             let res = self.tx.try_send((id, request, device.0.clone()));
             if res.is_err() {


### PR DESCRIPTION
Fix #5 

A lot of files may be ignored since they only changed formatting due to cargo fmt --all.
Important files include Ep2339 and/or MinasA6/Panasonic