### PR TITLE
Convert machine data trait impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +325,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "common"
@@ -537,6 +555,12 @@ dependencies = [
 
 [[package]]
 name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
@@ -547,7 +571,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
- "embedded-io",
+ "embedded-io 0.6.1",
 ]
 
 [[package]]
@@ -633,7 +657,7 @@ dependencies = [
  "embedded-io-async",
  "ethercrab-wire",
  "futures-lite",
- "heapless",
+ "heapless 0.8.0",
  "io-uring",
  "libc",
  "lock_api",
@@ -645,7 +669,7 @@ dependencies = [
  "slab",
  "smallvec",
  "smlang",
- "spin",
+ "spin 0.10.0",
  "timerfd",
 ]
 
@@ -655,7 +679,7 @@ version = "0.3.0"
 source = "git+https://github.com/ethercrab-rs/ethercrab?branch=main#4c7d36157fa5caab3194df494e92e08551cd2e43"
 dependencies = [
  "ethercrab-wire-derive",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -834,6 +858,15 @@ dependencies = [
 
 [[package]]
 name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
@@ -849,11 +882,25 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32",
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -1233,6 +1280,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless 0.7.17",
+ "serde",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1330,8 @@ dependencies = [
  "ethercat_hal_derive",
  "machines",
  "modbus",
+ "postcard",
+ "serde",
  "tokio",
  "units",
 ]
@@ -1354,6 +1416,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1475,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1540,6 +1617,15 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ units = {path = "units"}
 common = {path = "common"}
 tokio = "1.49.0"
 
+
+[dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
+postcard = { version = "1.0", features = ["alloc"] }
+
 [lib]
 
 [features]

--- a/examples/machine_data.rs
+++ b/examples/machine_data.rs
@@ -1,0 +1,62 @@
+use machines::{ConvertMachineData, MachineData};
+use postcard::from_bytes;
+use postcard::to_slice;
+use serde::{Deserialize, Serialize};
+use std::any::TypeId;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct MockData {
+    bytes_0_255: Vec<u8>,
+    str_data: String,
+    stack_bytes: [u8; 32],
+    max_u64: u64,
+    min_u64: u64,
+}
+
+/*
+    You have to supply your own implementation when converting from and to the given type
+    you can do it with json,yaml,bincode whatever best fits your use case
+*/
+impl ConvertMachineData for MockData {
+    fn to_machine_data(&self, data: &mut MachineData) -> Result<(), &'static str> {
+        let serialized_bytes =
+            to_slice(self, &mut data.data).map_err(|_| "Postcard serialization failed")?;
+        data.type_id = TypeId::of::<Self>();
+        data.length = serialized_bytes.len();
+        Ok(())
+    }
+
+    fn from_machine_data(machine_data: &MachineData, out: &mut Self) -> Result<(), &'static str> {
+        if machine_data.type_id != TypeId::of::<Self>() {
+            return Err("Typeid Mismatch");
+        }
+        if machine_data.length == 0 {
+            return Err("Empty buffer data");
+        }
+        let deserialized: Self =
+            from_bytes(&machine_data.data).map_err(|_| "Postcard deserialization failed")?;
+        *out = deserialized;
+        Ok(())
+    }
+}
+
+fn main() {
+    let mut mock = MockData {
+        stack_bytes: [0u8; 32],
+        max_u64: u64::MAX,
+        min_u64: u64::MIN,
+        bytes_0_255: vec![],
+        str_data: "str".to_owned(),
+    };
+    for i in 0..255 {
+        if i < 32 {
+            mock.stack_bytes[i as usize] = i;
+        }
+    }
+    println!("before: {:?}", mock);
+    let mut machine_data = MachineData::default();
+    mock.to_machine_data(&mut machine_data).unwrap();
+    let mut reconstructed_mock = MockData::default();
+    let _ = MockData::from_machine_data(&machine_data, &mut reconstructed_mock);
+    println!("reconstructed_mock: {:?}", reconstructed_mock);
+}

--- a/machines/src/lib.rs
+++ b/machines/src/lib.rs
@@ -22,22 +22,19 @@ impl MachineIdentificationUnique {
     }
 }
 
-#[repr(align(64))]
+
 pub struct MachineData {
     pub type_id: TypeId,
     pub length: usize,
     pub data: [u8; MAX_DATA_LEN],
 }
 
-/*
-    How should the raw data look like?
-    Initial state should be all zeroes
-    Endianness: Little endian
-    first 4 bytes: vendor,machine,serial
-    then 4 bytes data length: 256 for example
-    then the data: of 256 bytes
+impl Default for MachineData {
+    fn default() -> Self {
+        Self { type_id: TypeId::of::<()>(), length: 0, data: [0u8;2048] }
+    }
+}
 
-*/
 pub struct MachineDataRegistry {
     // Each slot is a fixed-size buffer
     pub storage: HashMap<MachineIdentificationUnique, MachineData>,
@@ -54,22 +51,29 @@ impl MachineDataRegistry {
         }
     }
 
-    pub fn store<T: ConvertMachineData>(
+    pub fn store<T: ConvertMachineData + Default>(
         &mut self,
         ident: MachineIdentificationUnique,
         value: &T,
-    ) -> Result<(), &'static str> {
-        let machine_data = value.to_machine_data()?;
-        self.storage.insert(ident, machine_data);
+    ) -> Result<(), &'static str> {        
+        self.storage.insert(ident, MachineData::default());
+        let v = self.storage.get_mut(&ident);
+        let machine_data = match v {
+            Some(v) => v,
+            None => return Err("Failed to insert machine_data"),
+        };
+        value.to_machine_data(machine_data)?;        
         Ok(())
     }
 
-    pub fn load<T: ConvertMachineData>(
+    pub fn load<T: ConvertMachineData + Default>(
         &self,
         ident: &MachineIdentificationUnique,
     ) -> Result<T, &'static str> {
         let machine_data = self.storage.get(ident).ok_or("No entry for ident")?;
-        T::from_machine_data(machine_data)
+        let mut result : T = T::default();
+        T::from_machine_data(machine_data,&mut result)?;
+        Ok(result)
     }
 }
 
@@ -86,37 +90,6 @@ pub trait Machine {
 }
 
 pub trait ConvertMachineData: Sized + 'static {
-    fn to_machine_data(&self) -> Result<MachineData, &'static str> {
-        let size = std::mem::size_of::<Self>();
-        if size > MAX_DATA_LEN {
-            return Err("Data exceeds MAX_DATA_LEN");
-        }
-        let mut data = MachineData {
-            type_id: TypeId::of::<Self>(),
-            length: size,
-            data: [0u8; MAX_DATA_LEN],
-        };
-
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                self as *const Self as *const u8,
-                data.data.as_mut_ptr(),
-                size,
-            );
-        }
-
-        Ok(data)
-    }
-
-    fn from_machine_data(machine_data: &MachineData) -> Result<Self, &'static str> {
-        if machine_data.type_id != TypeId::of::<Self>() {
-            return Err("TypeId mismatch");
-        }
-
-        if machine_data.length != std::mem::size_of::<Self>() {
-            return Err("Length mismatch");
-        }
-
-        unsafe { Ok(std::ptr::read(machine_data.data.as_ptr() as *const Self)) }
-    }
+    fn to_machine_data(&self,data : &mut MachineData) -> Result<(), &'static str>;    
+    fn from_machine_data(machine_data: &MachineData, out : &mut Self) -> Result<(), &'static str>;    
 }

--- a/machines/src/lib.rs
+++ b/machines/src/lib.rs
@@ -22,7 +22,6 @@ impl MachineIdentificationUnique {
     }
 }
 
-
 pub struct MachineData {
     pub type_id: TypeId,
     pub length: usize,
@@ -31,7 +30,11 @@ pub struct MachineData {
 
 impl Default for MachineData {
     fn default() -> Self {
-        Self { type_id: TypeId::of::<()>(), length: 0, data: [0u8;2048] }
+        Self {
+            type_id: TypeId::of::<()>(),
+            length: 0,
+            data: [0u8; 2048],
+        }
     }
 }
 
@@ -55,14 +58,14 @@ impl MachineDataRegistry {
         &mut self,
         ident: MachineIdentificationUnique,
         value: &T,
-    ) -> Result<(), &'static str> {        
+    ) -> Result<(), &'static str> {
         self.storage.insert(ident, MachineData::default());
         let v = self.storage.get_mut(&ident);
         let machine_data = match v {
             Some(v) => v,
             None => return Err("Failed to insert machine_data"),
         };
-        value.to_machine_data(machine_data)?;        
+        value.to_machine_data(machine_data)?;
         Ok(())
     }
 
@@ -71,8 +74,8 @@ impl MachineDataRegistry {
         ident: &MachineIdentificationUnique,
     ) -> Result<T, &'static str> {
         let machine_data = self.storage.get(ident).ok_or("No entry for ident")?;
-        let mut result : T = T::default();
-        T::from_machine_data(machine_data,&mut result)?;
+        let mut result: T = T::default();
+        T::from_machine_data(machine_data, &mut result)?;
         Ok(result)
     }
 }
@@ -90,6 +93,6 @@ pub trait Machine {
 }
 
 pub trait ConvertMachineData: Sized + 'static {
-    fn to_machine_data(&self,data : &mut MachineData) -> Result<(), &'static str>;    
-    fn from_machine_data(machine_data: &MachineData, out : &mut Self) -> Result<(), &'static str>;    
+    fn to_machine_data(&self, data: &mut MachineData) -> Result<(), &'static str>;
+    fn from_machine_data(machine_data: &MachineData, out: &mut Self) -> Result<(), &'static str>;
 }

--- a/machines/src/lib.rs
+++ b/machines/src/lib.rs
@@ -112,12 +112,11 @@ pub trait ConvertMachineData: Sized + 'static {
         if machine_data.type_id != TypeId::of::<Self>() {
             return Err("TypeId mismatch");
         }
+
         if machine_data.length != std::mem::size_of::<Self>() {
             return Err("Length mismatch");
         }
 
-        unsafe {
-            Ok(std::ptr::read(machine_data.data.as_ptr() as *const Self))
-        }
+        unsafe { Ok(std::ptr::read(machine_data.data.as_ptr() as *const Self)) }
     }
 }

--- a/machines/src/lib.rs
+++ b/machines/src/lib.rs
@@ -53,6 +53,24 @@ impl MachineDataRegistry {
             None => (),
         }
     }
+
+    pub fn store<T: ConvertMachineData>(
+        &mut self,
+        ident: MachineIdentificationUnique,
+        value: &T,
+    ) -> Result<(), &'static str> {
+        let machine_data = value.to_machine_data()?;
+        self.storage.insert(ident, machine_data);
+        Ok(())
+    }
+
+    pub fn load<T: ConvertMachineData>(
+        &self,
+        ident: &MachineIdentificationUnique,
+    ) -> Result<T, &'static str> {
+        let machine_data = self.storage.get(ident).ok_or("No entry for ident")?;
+        T::from_machine_data(machine_data)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -65,4 +83,41 @@ pub trait Machine {
     fn act(&mut self, machine_data: Option<&mut MachineDataRegistry>) -> Result<(), MachineError>;
     fn react(&mut self, registry: &MachineDataRegistry);
     fn get_identification(&self) -> MachineIdentificationUnique;
+}
+
+pub trait ConvertMachineData: Sized + 'static {
+    fn to_machine_data(&self) -> Result<MachineData, &'static str> {
+        let size = std::mem::size_of::<Self>();
+        if size > MAX_DATA_LEN {
+            return Err("Data exceeds MAX_DATA_LEN");
+        }
+        let mut data = MachineData {
+            type_id: TypeId::of::<Self>(),
+            length: size,
+            data: [0u8; MAX_DATA_LEN],
+        };
+
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                self as *const Self as *const u8,
+                data.data.as_mut_ptr(),
+                size,
+            );
+        }
+
+        Ok(data)
+    }
+
+    fn from_machine_data(machine_data: &MachineData) -> Result<Self, &'static str> {
+        if machine_data.type_id != TypeId::of::<Self>() {
+            return Err("TypeId mismatch");
+        }
+        if machine_data.length != std::mem::size_of::<Self>() {
+            return Err("Length mismatch");
+        }
+
+        unsafe {
+            Ok(std::ptr::read(machine_data.data.as_ptr() as *const Self))
+        }
+    }
 }


### PR DESCRIPTION
Introduces a lightweight mechanism for machines to exchange data through the MachineDataRegistry without direct coupling.

Added ConvertMachineData trait with default to_machine_data / from_machine_data implementations that handle the byte conversion via ptr::copy_nonoverlapping / ptr::read
Added store and load helper methods on MachineDataRegistry for ergonomic typed access

Any struct that is Sized + 'static and contains no heap allocations can opt in with a one-line impl. Type mismatches are caught at runtime through TypeId comparison, keeping the unsafe code sound.

