### PR TITLE
Fixed writing to eeprom for Beckhoff terminals

### DIFF
--- a/ethercat_hal/src/machine_ident_read.rs
+++ b/ethercat_hal/src/machine_ident_read.rs
@@ -78,19 +78,30 @@ pub fn write_device_identifications(
     let addresses = MachineDeviceAddresses::default();
     let rt = get_async_runtime();
     let res: Result<(), ethercrab::error::Error> = rt.block_on(async {
-        for (subdevice, info) in group.iter(maindevice).zip(identifications.iter()) {
+        for subdevice in group.iter(maindevice) {
+            let info = match identifications
+                .iter()
+                .find(|i| i.device_address == subdevice.configured_address())
+            {
+                Some(info) => info,
+                None => {
+                    tracing::debug!(
+                        "No identification found for subdevice at address {}, skipping",
+                        subdevice.configured_address()
+                    );
+                    continue;
+                }
+            };
+
             subdevice
                 .eeprom_write_dangerously(maindevice, addresses.vendor_word, info.machine_vendor)
                 .await?;
-
             subdevice
                 .eeprom_write_dangerously(maindevice, addresses.serial_word, info.machine_serial)
                 .await?;
-
             subdevice
                 .eeprom_write_dangerously(maindevice, addresses.machine_word, info.machine_id)
                 .await?;
-
             subdevice
                 .eeprom_write_dangerously(maindevice, addresses.role_word, info.role)
                 .await?;


### PR DESCRIPTION
Previous version did not Work for Beckhoff terminal since .zip does just pair by position instead of using the device address.