### PR TITLE
Add MacOS platform-specific handling for EtherCAT interface discovery

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,9 +2,10 @@ use std::sync::OnceLock;
 use tokio::runtime::Runtime;
 #[cfg(target_os = "linux")]
 use libc;
+#[cfg(target_os = "linux")]
 use std::ffi::CString;
+#[cfg(target_os = "linux")]
 use std::io;
-use std::str;
 
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 pub fn get_async_runtime() -> &'static Runtime {

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -559,10 +559,8 @@ impl EtherCATController<Arc<Mailbox>, TripleBufProducer> {
                         tick += 1;
                     };
 
-                    // Use request_into_op on non-Linux: requests OP state on all
-                    // subdevices without waiting for confirmation. Required on
-                    // non-real-time OSes (macOS) where state-check frames may
-                    // miss timing windows.
+                    // Use request_into_op on non-Linux (non-real-time OS) to skip
+                    // blocking state-confirmation wait.
                     #[cfg(target_os = "linux")]
                     {
                         group_op = Some(

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -559,24 +559,27 @@ impl EtherCATController<Arc<Mailbox>, TripleBufProducer> {
                         tick += 1;
                     };
 
-                    // Use request_into_op on non-Linux (non-real-time OS) to skip
-                    // blocking state-confirmation wait.
-                    #[cfg(target_os = "linux")]
+                    // Use the non-blocking request_into_op + manual tx_rx_dc polling loop
+                    // (handled below in the EtherCATState::Op branch via `all_op()`) on all
+                    // platforms. The blocking `into_op()` call was tried on Linux but its
+                    // internal polling pattern reliably triggered a latent io_uring TX/RX
+                    // race (Pdu(InvalidIndex) during the transition) that this older,
+                    // explicit-loop pattern does not hit.
+                    match rt.block_on(group_safe_op.request_into_op(&maindevice.as_ref().unwrap()))
                     {
-                        group_op = Some(
-                            rt.block_on(group_safe_op.into_op(&maindevice.as_ref().unwrap()))
-                                .expect("SAFE-OP -> OP"),
-                        );
-                    }
-                    #[cfg(not(target_os = "linux"))]
-                    {
-                        group_op = Some(
-                            rt.block_on(
-                                group_safe_op
-                                    .request_into_op(&maindevice.as_ref().unwrap()),
-                            )
-                            .expect("SAFE-OP -> OP (request)"),
-                        );
+                        Ok(group) => group_op = Some(group),
+                        Err(e) => {
+                            // request_into_op consumes the group, so there is no in-process
+                            // retry; a failure here usually means the TX/RX task died (PDU
+                            // storage cannot be re-split). Exit cleanly for a systemd restart
+                            // instead of panicking and leaving a half-initialized master behind.
+                            eprintln!(
+                                "EtherCAT SAFE-OP -> OP transition failed: {:?}. \
+                                 Exiting for a clean restart.",
+                                e
+                            );
+                            std::process::exit(1);
+                        }
                     }
 
                     println!("Started Transition to OP");

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use std::sync::Arc;
 use crate::Mailbox;
+#[cfg(target_os = "linux")]
 use common::set_irq_affinity;
 use ethercrab::{
     MainDevice, MainDeviceConfig, RegisterAddress, RetryBehaviour, SubDeviceGroup, Timeouts,
@@ -44,6 +45,7 @@ where
     output_consumer: C,
 }
 
+#[cfg(target_os = "linux")]
 fn set_current_thread_rt_priority(priority: i32) {
     unsafe {
         let thread_id = libc::pthread_self();
@@ -69,6 +71,13 @@ fn set_current_thread_rt_priority(priority: i32) {
             println!("Thread priority set to SCHED_FIFO with level {}", priority);
         }
     }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn set_current_thread_rt_priority(_priority: i32) {
+    eprintln!(
+        "set_current_thread_rt_priority: real-time scheduling is not available on this platform"
+    );
 }
 
 impl<C, P> EtherCATController<C, P>
@@ -157,41 +166,70 @@ impl EtherCATController<Arc<Mailbox>, TripleBufProducer> {
                         _ => continue,
                     }
 
+                    #[cfg(target_os = "linux")]
                     use ethercrab::std::tx_rx_task_io_uring;
+                    #[cfg(not(target_os = "linux"))]
+                    use ethercrab::std::tx_rx_task;
                     if self.interface.is_some() {
                         let (tx, rx, pdu) = PDU_STORAGE.try_split().expect("can only split once");
-                        let pdu_tx = tx;
-                        let pdu_rx = rx;
                         let interface = self.interface.clone().unwrap();
-                        let opt = self.current_config.realtime_optimizations.clone();
-                        _ethercat_tx_rx_handle = std::thread::Builder::new()
-                            .name("EthercatTxRxThread".to_owned())
-                            .spawn(move || {
-                                match opt {
-                                    Some(opt) => {
-                                        let id = core_affinity::CoreId {
-                                            id: opt.ethercat_io_thread_core,
-                                        };
-                                        set_current_thread_rt_priority(
-                                            opt.ethercat_io_thread_priority as i32,
-                                        );
-                                        // Pin to the last core (e.g., Core 3 on a 4-core system)
-                                        core_affinity::set_for_current(id);
-                                        if let Some(irq_core) = opt.pin_irq_core {
-                                            let res = set_irq_affinity(&interface, irq_core as u32);
-                                            if res.is_err() {
-                                                println!("set_irq_affinity failed: {:?}", res);
-                                            }else {
-                                                println!("set irq_affinity of {} to core {}",&interface,irq_core);
-                                            }
 
+                        #[cfg(target_os = "linux")]
+                        {
+                            let pdu_tx = tx;
+                            let pdu_rx = rx;
+                            let opt = self.current_config.realtime_optimizations.clone();
+                            _ethercat_tx_rx_handle = std::thread::Builder::new()
+                                .name("EthercatTxRxThread".to_owned())
+                                .spawn(move || {
+                                    match opt {
+                                        Some(opt) => {
+                                            let id = core_affinity::CoreId {
+                                                id: opt.ethercat_io_thread_core,
+                                            };
+                                            set_current_thread_rt_priority(
+                                                opt.ethercat_io_thread_priority as i32,
+                                            );
+                                            // Pin to the last core (e.g., Core 3 on a 4-core system)
+                                            core_affinity::set_for_current(id);
+                                            if let Some(irq_core) = opt.pin_irq_core {
+                                                let res = set_irq_affinity(&interface, irq_core as u32);
+                                                if res.is_err() {
+                                                    println!("set_irq_affinity failed: {:?}", res);
+                                                }else {
+                                                    println!("set irq_affinity of {} to core {}",&interface,irq_core);
+                                                }
+
+                                            }
                                         }
-                                    }
-                                    None => (),
-                                };
-                                tx_rx_task_io_uring(&interface, pdu_tx, pdu_rx)
-                                    .expect("Failed to run TX/RX task (io_uring)");
-                            });
+                                        None => (),
+                                    };
+                                    tx_rx_task_io_uring(&interface, pdu_tx, pdu_rx)
+                                        .expect("Failed to run TX/RX task (io_uring)");
+                                });
+                        }
+
+                        #[cfg(not(target_os = "linux"))]
+                        {
+                            let pdu_tx = tx;
+                            let pdu_rx = rx;
+                            _ethercat_tx_rx_handle = std::thread::Builder::new()
+                                .name("EthercatTxRxThread".to_owned())
+                                .spawn(move || {
+                                    get_async_runtime().block_on(async {
+                                        match tx_rx_task(&interface, pdu_tx, pdu_rx) {
+                                            Ok(task) => {
+                                                if let Err(e) = task.await {
+                                                    eprintln!("TX/RX task error: {}", e);
+                                                }
+                                            }
+                                            Err(e) => {
+                                                eprintln!("TX/RX task creation failed: {}", e);
+                                            }
+                                        }
+                                    });
+                                });
+                        }
 
                         maindevice = Some(MainDevice::new(
                             pdu,

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -559,10 +559,27 @@ impl EtherCATController<Arc<Mailbox>, TripleBufProducer> {
                         tick += 1;
                     };
 
-                    group_op = Some(
-                        rt.block_on(group_safe_op.into_op(&maindevice.as_ref().unwrap()))
-                            .expect("SAFE-OP -> OP"),
-                    );
+                    // Use request_into_op on non-Linux: requests OP state on all
+                    // subdevices without waiting for confirmation. Required on
+                    // non-real-time OSes (macOS) where state-check frames may
+                    // miss timing windows.
+                    #[cfg(target_os = "linux")]
+                    {
+                        group_op = Some(
+                            rt.block_on(group_safe_op.into_op(&maindevice.as_ref().unwrap()))
+                                .expect("SAFE-OP -> OP"),
+                        );
+                    }
+                    #[cfg(not(target_os = "linux"))]
+                    {
+                        group_op = Some(
+                            rt.block_on(
+                                group_safe_op
+                                    .request_into_op(&maindevice.as_ref().unwrap()),
+                            )
+                            .expect("SAFE-OP -> OP (request)"),
+                        );
+                    }
 
                     println!("Started Transition to OP");
                     self.state = EtherCATState::Op;

--- a/ethercat_hal/src/interface_discovery.rs
+++ b/ethercat_hal/src/interface_discovery.rs
@@ -167,40 +167,51 @@ pub fn test_interface(interface_name: &str) -> Result<(), anyhow::Error> {
 use std::{ffi::CString, mem, os::fd::RawFd};
 
 #[cfg(target_os = "macos")]
-const BIOCSETIF: libc::c_ulong = 0x8020426C;
-#[cfg(target_os = "macos")]
-const BIOCIMMEDIATE: libc::c_ulong = 0x80044272;
-#[cfg(target_os = "macos")]
-const IFNAMSIZ: usize = 16;
-
-/// Matches the real `struct ifreq` (144 bytes on 64-bit macOS).
-#[cfg(target_os = "macos")]
-#[repr(C)]
-struct Ifreq {
-    ifr_name: [u8; IFNAMSIZ],
-    _pad: [u8; 128],
-}
-
-#[cfg(target_os = "macos")]
 fn open_bpf(interface_name: &str) -> Result<RawFd, anyhow::Error> {
+    let name = interface_name.as_bytes();
+    if name.len() >= libc::IFNAMSIZ {
+        return Err(anyhow::anyhow!("Interface name too long: {interface_name}"));
+    }
     unsafe {
         for i in 0..256 {
             let dev = CString::new(format!("/dev/bpf{i}")).unwrap();
             let fd = libc::open(dev.as_ptr(), libc::O_RDWR | libc::O_NONBLOCK);
             if fd < 0 {
-                continue;
+                let err = std::io::Error::last_os_error();
+                match err.raw_os_error() {
+                    // Device in use — try the next one.
+                    Some(libc::EBUSY) => continue,
+                    // Past the last existing BPF node — all devices busy.
+                    Some(libc::ENOENT) => {
+                        return Err(anyhow::anyhow!(
+                            "No free BPF device (checked /dev/bpf0../dev/bpf{i})"
+                        ));
+                    }
+                    // EPERM/EACCES etc. — retrying other nodes won't help.
+                    _ => return Err(anyhow::anyhow!("Failed to open /dev/bpf{i}: {err}")),
+                }
             }
             // Immediate mode — read returns as soon as a packet arrives.
-            libc::ioctl(fd, BIOCIMMEDIATE, &1u32);
-
-            let mut ifr: Ifreq = mem::zeroed();
-            let name = interface_name.as_bytes();
-            let n = name.len().min(IFNAMSIZ - 1);
-            ifr.ifr_name[..n].copy_from_slice(&name[..n]);
-
-            if libc::ioctl(fd, BIOCSETIF, &ifr) == -1 {
+            let immediate: libc::c_uint = 1;
+            if libc::ioctl(fd, libc::BIOCIMMEDIATE, &immediate) == -1 {
+                let err = std::io::Error::last_os_error();
                 libc::close(fd);
-                continue;
+                return Err(anyhow::anyhow!(
+                    "BIOCIMMEDIATE on /dev/bpf{i} failed: {err}"
+                ));
+            }
+
+            let mut ifr: libc::ifreq = mem::zeroed();
+            for (dst, &src) in ifr.ifr_name.iter_mut().zip(name) {
+                *dst = src as libc::c_char;
+            }
+
+            if libc::ioctl(fd, libc::BIOCSETIF, &ifr) == -1 {
+                let err = std::io::Error::last_os_error();
+                libc::close(fd);
+                return Err(anyhow::anyhow!(
+                    "BIOCSETIF({interface_name}) on /dev/bpf{i} failed: {err}"
+                ));
             }
             return Ok(fd);
         }
@@ -208,27 +219,57 @@ fn open_bpf(interface_name: &str) -> Result<RawFd, anyhow::Error> {
     }
 }
 
+/// Scans a BPF read buffer (which may hold several concatenated records)
+/// for a captured frame with the EtherCAT EtherType (0x88a4).
+#[cfg(target_os = "macos")]
+fn contains_ethercat_frame(data: &[u8]) -> bool {
+    let align = libc::BPF_ALIGNMENT as usize;
+    let mut off = 0usize;
+    while off + mem::size_of::<libc::bpf_hdr>() <= data.len() {
+        let hdr =
+            unsafe { std::ptr::read_unaligned(data.as_ptr().add(off) as *const libc::bpf_hdr) };
+        let hdrlen = hdr.bh_hdrlen as usize;
+        let caplen = hdr.bh_caplen as usize;
+        if hdrlen < mem::size_of::<libc::bpf_hdr>() || off + hdrlen + caplen > data.len() {
+            break;
+        }
+        let pkt = &data[off + hdrlen..off + hdrlen + caplen];
+        if pkt.len() >= 14 && pkt[12] == 0x88 && pkt[13] == 0xa4 {
+            return true;
+        }
+        off += (hdrlen + caplen + align - 1) & !(align - 1);
+    }
+    false
+}
+
 #[cfg(target_os = "macos")]
 pub fn test_interface(interface_name: &str) -> Result<(), anyhow::Error> {
     // EtherCAT broadcast discovery frame padded to Ethernet minimum (60 bytes).
     const FRAME: [u8; 60] = [
-        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01,
-        0x88, 0xa4, 0x0d, 0x10, 0x08, 0x01, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01, 0x88, 0xa4, 0x0d,
+        0x10, 0x08, 0x01, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     ];
 
     let fd = open_bpf(interface_name)?;
-    let result = unsafe {
+    let result = probe_ethercat(fd, interface_name, &FRAME);
+    unsafe {
+        libc::close(fd);
+    }
+    result
+}
+
+#[cfg(target_os = "macos")]
+fn probe_ethercat(fd: RawFd, interface_name: &str, frame: &[u8]) -> Result<(), anyhow::Error> {
+    unsafe {
         let mut buf = [0u8; 4096];
 
         // Drain stale packets (non-blocking)
         while libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) > 0 {}
 
         // Send discovery frame
-        if libc::write(fd, FRAME.as_ptr() as *const libc::c_void, FRAME.len()) < 0 {
+        if libc::write(fd, frame.as_ptr() as *const libc::c_void, frame.len()) < 0 {
             return Err(anyhow::anyhow!(
                 "BPF write: {}",
                 std::io::Error::last_os_error()
@@ -236,14 +277,19 @@ pub fn test_interface(interface_name: &str) -> Result<(), anyhow::Error> {
         }
 
         // Wait for response (500ms timeout, non-blocking read + nanosleep)
-        let mut start = libc::timeval { tv_sec: 0, tv_usec: 0 };
+        let mut start = libc::timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        };
         libc::gettimeofday(&mut start, std::ptr::null_mut());
-        let received = loop {
+        loop {
             let n = libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len());
             if n > 0 {
-                break n;
-            }
-            if n < 0 {
+                if contains_ethercat_frame(&buf[..n as usize]) {
+                    return Ok(());
+                }
+                // Non-EtherCAT traffic — keep waiting until the timeout.
+            } else if n < 0 {
                 let e = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
                 if e != libc::EAGAIN && e != libc::EWOULDBLOCK {
                     return Err(anyhow::anyhow!(
@@ -252,37 +298,25 @@ pub fn test_interface(interface_name: &str) -> Result<(), anyhow::Error> {
                     ));
                 }
             }
-            let mut now = libc::timeval { tv_sec: 0, tv_usec: 0 };
+            let mut now = libc::timeval {
+                tv_sec: 0,
+                tv_usec: 0,
+            };
             libc::gettimeofday(&mut now, std::ptr::null_mut());
             let elapsed =
                 (now.tv_sec - start.tv_sec) * 1_000_000 + (now.tv_usec - start.tv_usec) as i64;
             if elapsed >= 500_000 {
-                return Err(anyhow::anyhow!(
-                    "No EtherCAT response on {interface_name}"
-                ));
+                return Err(anyhow::anyhow!("No EtherCAT response on {interface_name}"));
             }
             libc::nanosleep(
-                &libc::timespec { tv_sec: 0, tv_nsec: 1_000_000 },
+                &libc::timespec {
+                    tv_sec: 0,
+                    tv_nsec: 1_000_000,
+                },
                 std::ptr::null_mut(),
             );
-        };
-
-        // Parse BPF header: macOS ARM64 uses timeval32 (18-byte header),
-        // bh_hdrlen is a u16 at offset 16.
-        let hdrlen_raw = u16::from_le_bytes([buf[16], buf[17]]) as usize;
-        let hdrlen = if hdrlen_raw < 14 || hdrlen_raw > 256 { 18 } else { hdrlen_raw };
-        if (received as usize) <= hdrlen {
-            return Err(anyhow::anyhow!("No packet data in BPF response"));
         }
-        let pkt = &buf[hdrlen..];
-        if pkt.len() >= 14 && pkt[12] == 0x88 && pkt[13] == 0xa4 {
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!("{interface_name:?} is not Ethercat"))
-        }
-    };
-    unsafe { libc::close(fd); }
-    result
+    }
 }
 
 // ── Other platforms (neither Linux nor macOS) ─────────────────────────

--- a/ethercat_hal/src/interface_discovery.rs
+++ b/ethercat_hal/src/interface_discovery.rs
@@ -160,213 +160,129 @@ pub fn test_interface(interface_name: &str) -> Result<(), anyhow::Error> {
     }
 }
 
-// ── macOS BPF (Berkeley Packet Filter) implementation ──────────────────
-// BPF is the native raw-packet mechanism on macOS / BSD.
-// We open /dev/bpfN, bind it to the interface via BIOCSETIF, send the
-// EtherCAT broadcast discovery frame, and check whether a response with
-// EtherType 0x88A4 comes back.  No ethercrab / AF_PACKET required.
+// ── macOS BPF (Berkeley Packet Filter) ────────────────────────────────
+// Native raw-packet I/O via /dev/bpfN.  No ethercrab / AF_PACKET required.
 
 #[cfg(target_os = "macos")]
 use std::{ffi::CString, mem, os::fd::RawFd};
 
-// BPF ioctl request numbers (from <net/bpf.h>, computed for 64-bit macOS).
 #[cfg(target_os = "macos")]
-const BIOCSETIF: libc::c_ulong = 0x8020426C; // _IOW('B', 108, struct ifreq)
+const BIOCSETIF: libc::c_ulong = 0x8020426C;
 #[cfg(target_os = "macos")]
-const BIOCIMMEDIATE: libc::c_ulong = 0x80044272; // _IOW('B', 114, u_int)
-// Note: BIOCGBLEN / BIOCSBLEN omitted — default 4096-byte BPF buffer is
-// sufficient, and macOS libc variadic ioctl ABI breaks _IOWR on aarch64.
-
+const BIOCIMMEDIATE: libc::c_ulong = 0x80044272;
 #[cfg(target_os = "macos")]
 const IFNAMSIZ: usize = 16;
 
-/// `struct ifreq` – macOS definition.
-/// The kernel writes into the union portion during BIOCSETIF, so the struct
-/// must be at least as large as the real `struct ifreq` (144 bytes on 64-bit).
+/// Matches the real `struct ifreq` (144 bytes on 64-bit macOS).
 #[cfg(target_os = "macos")]
 #[repr(C)]
 struct Ifreq {
     ifr_name: [u8; IFNAMSIZ],
-    _pad: [u8; 128], // covers the sockaddr_storage union (128 bytes)
+    _pad: [u8; 128],
 }
 
-/// Try to claim a free BPF device and bind it to `interface_name`.
 #[cfg(target_os = "macos")]
 fn open_bpf(interface_name: &str) -> Result<RawFd, anyhow::Error> {
     unsafe {
         for i in 0..256 {
-            let dev_path =
-                CString::new(format!("/dev/bpf{i}")).map_err(|_| anyhow::anyhow!("CString"))?;
-            let fd = libc::open(dev_path.as_ptr(), libc::O_RDWR | libc::O_NONBLOCK);
+            let dev = CString::new(format!("/dev/bpf{i}")).unwrap();
+            let fd = libc::open(dev.as_ptr(), libc::O_RDWR | libc::O_NONBLOCK);
             if fd < 0 {
-                continue; // device busy or non-existent, try next
+                continue;
             }
+            // Immediate mode — read returns as soon as a packet arrives.
+            libc::ioctl(fd, BIOCIMMEDIATE, &1u32);
 
-            // Immediate mode – read returns as soon as a packet arrives.
-            // Must be set before BIOCSETIF.
-            let enable: libc::c_uint = 1;
-            libc::ioctl(fd, BIOCIMMEDIATE, &enable);
-
-            // Bind to the requested interface.
-            // macOS bpf(4) provides a default buffer if not explicitly set
-            // via BIOCSBLEN before BIOCSETIF — 4096 bytes, sufficient for
-            // our single discovery frame.
             let mut ifr: Ifreq = mem::zeroed();
-            let name_bytes = interface_name.as_bytes();
-            let copy_len = name_bytes.len().min(IFNAMSIZ - 1);
-            ifr.ifr_name[..copy_len].copy_from_slice(&name_bytes[..copy_len]);
+            let name = interface_name.as_bytes();
+            let n = name.len().min(IFNAMSIZ - 1);
+            ifr.ifr_name[..n].copy_from_slice(&name[..n]);
 
             if libc::ioctl(fd, BIOCSETIF, &ifr) == -1 {
                 libc::close(fd);
                 continue;
             }
-
             return Ok(fd);
         }
-        Err(anyhow::anyhow!(
-            "No free BPF device available (tried /dev/bpf0–255)"
-        ))
+        Err(anyhow::anyhow!("No free BPF device"))
     }
 }
 
 #[cfg(target_os = "macos")]
 pub fn test_interface(interface_name: &str) -> Result<(), anyhow::Error> {
-    // EtherCAT broadcast discovery frame, padded to 60 bytes.
-    // Ethernet minimum frame is 64 bytes (60 payload + 4 FCS).
-    // macOS BPF requires the caller to pad — undersized frames are
-    // silently dropped by the NIC hardware.
-    const ETHERCAT_DISCOVERY_FRAME: [u8; 60] = [
-        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // dst MAC (broadcast)
-        0x02, 0x00, 0x00, 0x00, 0x00, 0x01, // src MAC (locally-administered unicast)
-        0x88, 0xa4, // EtherType = EtherCAT
-        0x0d, 0x10, 0x08, 0x01, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00,
-        // padding to 60 bytes (zeros)
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00,
+    // EtherCAT broadcast discovery frame padded to Ethernet minimum (60 bytes).
+    const FRAME: [u8; 60] = [
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01,
+        0x88, 0xa4, 0x0d, 0x10, 0x08, 0x01, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     ];
 
-    eprintln!("[BPF] testing {interface_name}...");
     let fd = open_bpf(interface_name)?;
-
     let result = unsafe {
-        // ── Drain any stale packets (non-blocking) ─────────────────────
-        let mut drain = [0u8; 4096];
-        loop {
-            let mut pfd = libc::pollfd {
-                fd,
-                events: libc::POLLIN,
-                revents: 0,
-            };
-            if libc::poll(&mut pfd, 1, 0) <= 0 {
-                break;
-            }
-            let n = libc::read(fd, drain.as_mut_ptr() as *mut libc::c_void, drain.len());
-            if n <= 0 {
-                break;
-            }
-        }
+        let mut buf = [0u8; 4096];
 
-        // ── Send EtherCAT broadcast discovery frame ────────────────────
-        let sent = libc::write(
-            fd,
-            ETHERCAT_DISCOVERY_FRAME.as_ptr() as *const libc::c_void,
-            ETHERCAT_DISCOVERY_FRAME.len(),
-        );
-        if sent < 0 {
+        // Drain stale packets (non-blocking)
+        while libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) > 0 {}
+
+        // Send discovery frame
+        if libc::write(fd, FRAME.as_ptr() as *const libc::c_void, FRAME.len()) < 0 {
             return Err(anyhow::anyhow!(
-                "BPF write failed: {}",
+                "BPF write: {}",
                 std::io::Error::last_os_error()
             ));
         }
 
-        // ── Wait for a response (500 ms, non-blocking read loop) ───────
-        // macOS poll() is unreliable on BPF descriptors — use non-blocking
-        // read with nanosleep backoff instead.
-        let mut buf = [0u8; 4096];
-        let mut received;
-        let start = libc::timeval {
-            tv_sec: 0,
-            tv_usec: 0,
-        };
-        libc::gettimeofday(
-            &start as *const libc::timeval as *mut libc::timeval,
-            std::ptr::null_mut(),
-        );
-        let timeout_us = 500_000i64;
-        loop {
-            received = libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len());
-            if received > 0 {
-                break; // got a packet
+        // Wait for response (500ms timeout, non-blocking read + nanosleep)
+        let mut start = libc::timeval { tv_sec: 0, tv_usec: 0 };
+        libc::gettimeofday(&mut start, std::ptr::null_mut());
+        let received = loop {
+            let n = libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len());
+            if n > 0 {
+                break n;
             }
-            if received < 0 {
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() != Some(libc::EAGAIN)
-                    && err.raw_os_error() != Some(libc::EWOULDBLOCK)
-                {
-                    eprintln!("[BPF] read error: {err}");
-                    return Err(anyhow::anyhow!("BPF read failed: {err}"));
+            if n < 0 {
+                let e = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+                if e != libc::EAGAIN && e != libc::EWOULDBLOCK {
+                    return Err(anyhow::anyhow!(
+                        "BPF read: {}",
+                        std::io::Error::last_os_error()
+                    ));
                 }
             }
-            // Check elapsed time
-            let mut now = libc::timeval {
-                tv_sec: 0,
-                tv_usec: 0,
-            };
+            let mut now = libc::timeval { tv_sec: 0, tv_usec: 0 };
             libc::gettimeofday(&mut now, std::ptr::null_mut());
             let elapsed =
-                (now.tv_sec - start.tv_sec) as i64 * 1_000_000 + (now.tv_usec - start.tv_usec) as i64;
-            if elapsed >= timeout_us {
-                eprintln!("[BPF] timeout — no response within 500ms");
+                (now.tv_sec - start.tv_sec) * 1_000_000 + (now.tv_usec - start.tv_usec) as i64;
+            if elapsed >= 500_000 {
                 return Err(anyhow::anyhow!(
-                    "No EtherCAT response on {interface_name} (timeout)"
+                    "No EtherCAT response on {interface_name}"
                 ));
             }
-            // Sleep 1ms before retrying
-            let ts = libc::timespec {
-                tv_sec: 0,
-                tv_nsec: 1_000_000,
-            };
-            libc::nanosleep(&ts, std::ptr::null_mut());
-        }
+            libc::nanosleep(
+                &libc::timespec { tv_sec: 0, tv_nsec: 1_000_000 },
+                std::ptr::null_mut(),
+            );
+        };
 
-        // Parse BPF header (macOS uses timeval32 → 18-byte header, hdrlen at offset 16)
-        let hdrlen = u16::from_le_bytes([buf[16], buf[17]]) as usize;
-
-        if hdrlen < 14 || hdrlen > 256 {
-            eprintln!("[BPF] hdrlen {hdrlen} looks invalid, trying fallback hdrlen=18");
-            let hdrlen = 18usize;
-            if (received as usize) <= hdrlen {
-                eprintln!("[BPF] no packet data with fallback hdrlen");
-                return Err(anyhow::anyhow!("No packet data in BPF response"));
-            }
-            let pkt = &buf[hdrlen..];
-            check_ethercat(interface_name, pkt)
-        } else if (received as usize) <= hdrlen {
-            eprintln!("[BPF] no packet data: received={received}, hdrlen={hdrlen}");
+        // Parse BPF header: macOS ARM64 uses timeval32 (18-byte header),
+        // bh_hdrlen is a u16 at offset 16.
+        let hdrlen_raw = u16::from_le_bytes([buf[16], buf[17]]) as usize;
+        let hdrlen = if hdrlen_raw < 14 || hdrlen_raw > 256 { 18 } else { hdrlen_raw };
+        if (received as usize) <= hdrlen {
             return Err(anyhow::anyhow!("No packet data in BPF response"));
+        }
+        let pkt = &buf[hdrlen..];
+        if pkt.len() >= 14 && pkt[12] == 0x88 && pkt[13] == 0xa4 {
+            Ok(())
         } else {
-            let pkt = &buf[hdrlen..];
-            check_ethercat(interface_name, pkt)
+            Err(anyhow::anyhow!("{interface_name:?} is not Ethercat"))
         }
     };
-
-    unsafe {
-        libc::close(fd);
-    }
+    unsafe { libc::close(fd); }
     result
-}
-
-#[cfg(target_os = "macos")]
-fn check_ethercat(interface_name: &str, pkt: &[u8]) -> Result<(), anyhow::Error> {
-    if pkt.len() >= 14 && pkt[12] == 0x88 && pkt[13] == 0xa4 {
-        Ok(())
-    } else {
-        Err(anyhow::anyhow!(
-            "Interface {interface_name:?} is not Ethercat"
-        ))
-    }
 }
 
 // ── Other platforms (neither Linux nor macOS) ─────────────────────────

--- a/ethercat_hal/src/interface_discovery.rs
+++ b/ethercat_hal/src/interface_discovery.rs
@@ -1,6 +1,7 @@
 use libc::{freeifaddrs, getifaddrs, ifaddrs};
 use std::ffi::CStr;
 use std::ptr;
+#[cfg(target_os = "linux")]
 use std::{ffi::CString, mem, os::fd::RawFd};
 
 #[derive(Debug)]
@@ -48,7 +49,13 @@ pub fn list_ethernet_interfaces() -> Result<Vec<Interface>, anyhow::Error> {
                             link_type: LinkType::Ipv6,
                             name,
                         },
+                        #[cfg(target_os = "linux")]
                         libc::AF_PACKET => Interface {
+                            link_type: LinkType::Link,
+                            name,
+                        },
+                        #[cfg(target_os = "macos")]
+                        libc::AF_LINK => Interface {
                             link_type: LinkType::Link,
                             name,
                         },
@@ -73,6 +80,7 @@ pub fn list_ethernet_interfaces() -> Result<Vec<Interface>, anyhow::Error> {
 }
 
 // RawFd is just a c_int (i32 basically)
+#[cfg(target_os = "linux")]
 fn open_raw_socket_libc(iface: &str) -> Result<RawFd, anyhow::Error> {
     unsafe {
         let protocol = (0x88a4u16).to_be() as i32; // EtherCAT EtherType
@@ -120,6 +128,7 @@ fn open_raw_socket_libc(iface: &str) -> Result<RawFd, anyhow::Error> {
     }
 }
 
+#[cfg(target_os = "linux")]
 fn test_discovery(fd: RawFd, packet: &[u8]) -> bool {
     unsafe {
         let sent = libc::send(fd, packet.as_ptr() as *const libc::c_void, packet.len(), 0);
@@ -134,6 +143,7 @@ fn test_discovery(fd: RawFd, packet: &[u8]) -> bool {
     }
 }
 
+#[cfg(target_os = "linux")]
 pub fn test_interface(interface_name: &str) -> Result<(), anyhow::Error> {
     const ETHERCAT_DISCOVERY_FRAME: [u8; 29] = [
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x88, 0xa4, 0xd, 0x10,
@@ -148,4 +158,12 @@ pub fn test_interface(interface_name: &str) -> Result<(), anyhow::Error> {
             interface_name
         ))
     }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn test_interface(interface_name: &str) -> Result<(), anyhow::Error> {
+    Err(anyhow::anyhow!(
+        "EtherCAT interface discovery is not available on this platform (interface: {})",
+        interface_name
+    ))
 }

--- a/ethercat_hal/src/interface_discovery.rs
+++ b/ethercat_hal/src/interface_discovery.rs
@@ -160,7 +160,217 @@ pub fn test_interface(interface_name: &str) -> Result<(), anyhow::Error> {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+// ── macOS BPF (Berkeley Packet Filter) implementation ──────────────────
+// BPF is the native raw-packet mechanism on macOS / BSD.
+// We open /dev/bpfN, bind it to the interface via BIOCSETIF, send the
+// EtherCAT broadcast discovery frame, and check whether a response with
+// EtherType 0x88A4 comes back.  No ethercrab / AF_PACKET required.
+
+#[cfg(target_os = "macos")]
+use std::{ffi::CString, mem, os::fd::RawFd};
+
+// BPF ioctl request numbers (from <net/bpf.h>, computed for 64-bit macOS).
+#[cfg(target_os = "macos")]
+const BIOCSETIF: libc::c_ulong = 0x8020426C; // _IOW('B', 108, struct ifreq)
+#[cfg(target_os = "macos")]
+const BIOCIMMEDIATE: libc::c_ulong = 0x80044272; // _IOW('B', 114, u_int)
+// Note: BIOCGBLEN / BIOCSBLEN omitted — default 4096-byte BPF buffer is
+// sufficient, and macOS libc variadic ioctl ABI breaks _IOWR on aarch64.
+
+#[cfg(target_os = "macos")]
+const IFNAMSIZ: usize = 16;
+
+/// `struct ifreq` – macOS definition.
+/// The kernel writes into the union portion during BIOCSETIF, so the struct
+/// must be at least as large as the real `struct ifreq` (144 bytes on 64-bit).
+#[cfg(target_os = "macos")]
+#[repr(C)]
+struct Ifreq {
+    ifr_name: [u8; IFNAMSIZ],
+    _pad: [u8; 128], // covers the sockaddr_storage union (128 bytes)
+}
+
+/// Try to claim a free BPF device and bind it to `interface_name`.
+#[cfg(target_os = "macos")]
+fn open_bpf(interface_name: &str) -> Result<RawFd, anyhow::Error> {
+    unsafe {
+        for i in 0..256 {
+            let dev_path =
+                CString::new(format!("/dev/bpf{i}")).map_err(|_| anyhow::anyhow!("CString"))?;
+            let fd = libc::open(dev_path.as_ptr(), libc::O_RDWR | libc::O_NONBLOCK);
+            if fd < 0 {
+                continue; // device busy or non-existent, try next
+            }
+
+            // Immediate mode – read returns as soon as a packet arrives.
+            // Must be set before BIOCSETIF.
+            let enable: libc::c_uint = 1;
+            libc::ioctl(fd, BIOCIMMEDIATE, &enable);
+
+            // Bind to the requested interface.
+            // macOS bpf(4) provides a default buffer if not explicitly set
+            // via BIOCSBLEN before BIOCSETIF — 4096 bytes, sufficient for
+            // our single discovery frame.
+            let mut ifr: Ifreq = mem::zeroed();
+            let name_bytes = interface_name.as_bytes();
+            let copy_len = name_bytes.len().min(IFNAMSIZ - 1);
+            ifr.ifr_name[..copy_len].copy_from_slice(&name_bytes[..copy_len]);
+
+            if libc::ioctl(fd, BIOCSETIF, &ifr) == -1 {
+                libc::close(fd);
+                continue;
+            }
+
+            return Ok(fd);
+        }
+        Err(anyhow::anyhow!(
+            "No free BPF device available (tried /dev/bpf0–255)"
+        ))
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn test_interface(interface_name: &str) -> Result<(), anyhow::Error> {
+    // EtherCAT broadcast discovery frame, padded to 60 bytes.
+    // Ethernet minimum frame is 64 bytes (60 payload + 4 FCS).
+    // macOS BPF requires the caller to pad — undersized frames are
+    // silently dropped by the NIC hardware.
+    const ETHERCAT_DISCOVERY_FRAME: [u8; 60] = [
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // dst MAC (broadcast)
+        0x02, 0x00, 0x00, 0x00, 0x00, 0x01, // src MAC (locally-administered unicast)
+        0x88, 0xa4, // EtherType = EtherCAT
+        0x0d, 0x10, 0x08, 0x01, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00,
+        // padding to 60 bytes (zeros)
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00,
+    ];
+
+    eprintln!("[BPF] testing {interface_name}...");
+    let fd = open_bpf(interface_name)?;
+
+    let result = unsafe {
+        // ── Drain any stale packets (non-blocking) ─────────────────────
+        let mut drain = [0u8; 4096];
+        loop {
+            let mut pfd = libc::pollfd {
+                fd,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            if libc::poll(&mut pfd, 1, 0) <= 0 {
+                break;
+            }
+            let n = libc::read(fd, drain.as_mut_ptr() as *mut libc::c_void, drain.len());
+            if n <= 0 {
+                break;
+            }
+        }
+
+        // ── Send EtherCAT broadcast discovery frame ────────────────────
+        let sent = libc::write(
+            fd,
+            ETHERCAT_DISCOVERY_FRAME.as_ptr() as *const libc::c_void,
+            ETHERCAT_DISCOVERY_FRAME.len(),
+        );
+        if sent < 0 {
+            return Err(anyhow::anyhow!(
+                "BPF write failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+
+        // ── Wait for a response (500 ms, non-blocking read loop) ───────
+        // macOS poll() is unreliable on BPF descriptors — use non-blocking
+        // read with nanosleep backoff instead.
+        let mut buf = [0u8; 4096];
+        let mut received;
+        let start = libc::timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        };
+        libc::gettimeofday(
+            &start as *const libc::timeval as *mut libc::timeval,
+            std::ptr::null_mut(),
+        );
+        let timeout_us = 500_000i64;
+        loop {
+            received = libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len());
+            if received > 0 {
+                break; // got a packet
+            }
+            if received < 0 {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() != Some(libc::EAGAIN)
+                    && err.raw_os_error() != Some(libc::EWOULDBLOCK)
+                {
+                    eprintln!("[BPF] read error: {err}");
+                    return Err(anyhow::anyhow!("BPF read failed: {err}"));
+                }
+            }
+            // Check elapsed time
+            let mut now = libc::timeval {
+                tv_sec: 0,
+                tv_usec: 0,
+            };
+            libc::gettimeofday(&mut now, std::ptr::null_mut());
+            let elapsed =
+                (now.tv_sec - start.tv_sec) as i64 * 1_000_000 + (now.tv_usec - start.tv_usec) as i64;
+            if elapsed >= timeout_us {
+                eprintln!("[BPF] timeout — no response within 500ms");
+                return Err(anyhow::anyhow!(
+                    "No EtherCAT response on {interface_name} (timeout)"
+                ));
+            }
+            // Sleep 1ms before retrying
+            let ts = libc::timespec {
+                tv_sec: 0,
+                tv_nsec: 1_000_000,
+            };
+            libc::nanosleep(&ts, std::ptr::null_mut());
+        }
+
+        // Parse BPF header (macOS uses timeval32 → 18-byte header, hdrlen at offset 16)
+        let hdrlen = u16::from_le_bytes([buf[16], buf[17]]) as usize;
+
+        if hdrlen < 14 || hdrlen > 256 {
+            eprintln!("[BPF] hdrlen {hdrlen} looks invalid, trying fallback hdrlen=18");
+            let hdrlen = 18usize;
+            if (received as usize) <= hdrlen {
+                eprintln!("[BPF] no packet data with fallback hdrlen");
+                return Err(anyhow::anyhow!("No packet data in BPF response"));
+            }
+            let pkt = &buf[hdrlen..];
+            check_ethercat(interface_name, pkt)
+        } else if (received as usize) <= hdrlen {
+            eprintln!("[BPF] no packet data: received={received}, hdrlen={hdrlen}");
+            return Err(anyhow::anyhow!("No packet data in BPF response"));
+        } else {
+            let pkt = &buf[hdrlen..];
+            check_ethercat(interface_name, pkt)
+        }
+    };
+
+    unsafe {
+        libc::close(fd);
+    }
+    result
+}
+
+#[cfg(target_os = "macos")]
+fn check_ethercat(interface_name: &str, pkt: &[u8]) -> Result<(), anyhow::Error> {
+    if pkt.len() >= 14 && pkt[12] == 0x88 && pkt[13] == 0xa4 {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "Interface {interface_name:?} is not Ethercat"
+        ))
+    }
+}
+
+// ── Other platforms (neither Linux nor macOS) ─────────────────────────
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub fn test_interface(interface_name: &str) -> Result<(), anyhow::Error> {
     Err(anyhow::anyhow!(
         "EtherCAT interface discovery is not available on this platform (interface: {})",

--- a/ethercat_hal/src/interface_discovery.rs
+++ b/ethercat_hal/src/interface_discovery.rs
@@ -150,14 +150,16 @@ pub fn test_interface(interface_name: &str) -> Result<(), anyhow::Error> {
         0x8, 0x1, 0x0, 0x0, 0x3, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     ];
     let fd = open_raw_socket_libc(interface_name)?;
-    if test_discovery(fd, &ETHERCAT_DISCOVERY_FRAME) {
+    let result = if test_discovery(fd, &ETHERCAT_DISCOVERY_FRAME) {
         Ok(())
     } else {
         Err(anyhow::anyhow!(
             "Interface {:?} is not Ethercat",
             interface_name
         ))
-    }
+    };
+    unsafe { libc::close(fd) };
+    result
 }
 
 // ── macOS BPF (Berkeley Packet Filter) ────────────────────────────────


### PR DESCRIPTION
This PR adds cross-platform support for EtherCAT, extending functionality from Linux-only to also support macOS.

It introduces macOS-specific raw packet handling via BPF and updates interface discovery to support both Linux (AF_PACKET) and macOS (AF_LINK). Linux-only raw socket and discovery code is conditionally compiled out on other platforms, with clearer fallback errors added.