### PR TITLE
tx rx pipelining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,6 +1326,7 @@ version = "0.1.0"
 dependencies = [
  "bitvec",
  "common",
+ "core_affinity",
  "ethercat_hal",
  "ethercat_hal_derive",
  "machines",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tokio = "1.49.0"
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 postcard = { version = "1.0", features = ["alloc"] }
+core_affinity = "0.8.3"
 
 [lib]
 

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -543,21 +543,6 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                         let mut is_all_op = false;
                         let mut not_all_op_cycles: u32 = 0;
                         loop {
-                            match self.output_consumer.read() {
-                                Some(full_buffer) => {
-                                    let mut current_offset = 0;
-                                    for subdevice in group.iter(&maindevice) {
-                                        let mut output = subdevice.outputs_raw_mut();
-                                        let len = output.len();
-                                        output.copy_from_slice(
-                                            &full_buffer[current_offset..current_offset + len],
-                                        );
-                                        current_offset += len;
-                                    }
-                                    self.output_consumer.finish_read();
-                                }
-                                None => {}
-                            };
                             let cycle_start = Instant::now();
                             let res = group.tx_rx_dc(&maindevice).await.expect("TX_RX Failed");
                             self.dc_system_time_ns
@@ -642,9 +627,27 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                             } else {
                                 self.cycle.fetch_add(1, Relaxed);
                             }
+
+                            spinner.sleep_until(self.next_cycle - Duration::from_micros(10));
+                            match self.output_consumer.read() {
+                                Some(full_buffer) => {
+                                    let mut current_offset = 0;
+                                    for subdevice in group.iter(&maindevice) {
+                                        let mut output = subdevice.outputs_raw_mut();
+                                        let len = output.len();
+                                        output.copy_from_slice(
+                                            &full_buffer[current_offset..current_offset + len],
+                                        );
+                                        current_offset += len;
+                                    }
+                                    self.output_consumer.finish_read();
+                                }
+                                None => {}
+                            };
                             spinner.sleep_until(self.next_cycle);
                             self.cycle_time_us
                                 .store(cycle_start.elapsed().as_micros() as u64, Relaxed);
+
                         }
                     });
                 }

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -2,7 +2,7 @@ use crate::ethercat_helpers::configure_oversampling;
 use crate::ethercat_helpers::enable_dc_sync01;
 use crate::{
     ChannelRequests, ChannelResponse, Consumer, ETHERCAT_TX_RX_SIZE, EtherCATState, MAX_SUBDEVICES,
-    PDI_LEN, PDU_STORAGE, Producer, SdoType, TripleBufProducer,
+    PDI_LEN, PDU_STORAGE, Producer, SdoType,
     ethercat_helpers::{enable_dc_sync, sdo_read, sdo_write},
     get_async_runtime,
     machine_ident_read::{read_device_identifications, write_device_identifications},
@@ -27,7 +27,7 @@ use std::{
 };
 use ta::{Next, indicators::ExponentialMovingAverage};
 
-impl EtherCATController<Arc<Mailbox>, TripleBufProducer> {
+impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
     pub fn ethercat_state_machine(&mut self) -> Result<(), anyhow::Error> {
         let mut _ethercat_tx_rx_handle: Result<JoinHandle<()>, std::io::Error>;
         let mut group: Option<SubDeviceGroup<MAX_SUBDEVICES, PDI_LEN, ethercrab::DefaultLock>> =
@@ -544,10 +544,11 @@ impl EtherCATController<Arc<Mailbox>, TripleBufProducer> {
                         let mut not_all_op_cycles: u32 = 0;
                         loop {
                             let cycle_start = Instant::now();
-                            let res = group.tx_rx_dc(&maindevice).await.expect("TX_RX Failed");
+                            let res = group.tx_rx_dc(&maindevice).await.expect("TX_RX Failed");                            
                             self.dc_system_time_ns
-                                .store(res.extra.dc_system_time, Relaxed);
+                                .store(res.extra.dc_system_time, Relaxed);                            
                             self.next_cycle = cycle_start + res.extra.next_cycle_wait;
+
                             if !is_all_op {
                                 if res.all_op() {
                                     let mut subdevice_guard = self.subdevices.lock().await;
@@ -637,6 +638,7 @@ impl EtherCATController<Arc<Mailbox>, TripleBufProducer> {
                                 }
                                 None => {}
                             }
+
                             if self.cycle.load(Relaxed) == u64::MAX {
                                 self.cycle.store(0, Relaxed);
                             } else {

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -541,9 +541,27 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                         };
 
                         let mut is_all_op = false;
-                        let mut not_all_op_cycles: u32 = 0;
+                        let mut not_all_op_cycles: u32 = 0;    
+                        let mut no_outputs: usize = 0;                    
                         loop {
                             let cycle_start = Instant::now();
+                            match self.output_consumer.read() {
+                                    Some(full_buffer) => {
+                                        let mut current_offset = 0;
+                                            for subdevice in group.iter(&maindevice) {
+                                                let mut output = subdevice.outputs_raw_mut();
+                                                let len = output.len();
+                                                output.copy_from_slice(
+                                                            &full_buffer[current_offset..current_offset + len],
+                                                );
+                                                current_offset += len;
+                                            }
+                                    self.output_consumer.finish_read();
+                                }
+                                None => {                                                                    
+                                }
+                            };
+
                             let res = group.tx_rx_dc(&maindevice).await.expect("TX_RX Failed");                            
                             self.dc_system_time_ns
                                 .store(res.extra.dc_system_time, Relaxed);                            
@@ -603,40 +621,23 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                                 }
                             }
 
-                            match self.output_consumer.read() {
-                                Some(full_buffer) => {
-                                    // We get a mutable slice to the whole buffer to make sub-slicing easier
-                                    let mut current_offset = 0;
-                                    for subdevice in group.iter(&maindevice) {
-                                        let mut output = subdevice.outputs_raw_mut();
-                                        let len = output.len();
-                                        output.copy_from_slice(
-                                            &full_buffer[current_offset..current_offset + len],
-                                        );
-                                        current_offset += len;
-                                    }
-                                    self.output_consumer.finish_read();
-                                }
-                                None => {}
-                            };
-
-                            match self.input_producer.input_buffer_mut() {
+                             match self.input_producer.input_buffer_mut() {
                                 Some(buffer) => {
-                                    // We get a mutable slice to the whole buffer to make sub-slicing easier
-                                    let mut current_offset = 0;
-                                    for subdevice in group.iter(&maindevice) {
-                                        let len = subdevice.io_raw().inputs().len();
-                                        if current_offset + len <= ETHERCAT_TX_RX_SIZE {
-                                            buffer[current_offset..current_offset + len]
-                                                .copy_from_slice(subdevice.io_raw().inputs());
-                                            current_offset += len;
-                                        } else {
-                                            break;
+                                        // We get a mutable slice to the whole buffer to make sub-slicing easier
+                                        let mut current_offset = 0;
+                                        for subdevice in group.iter(&maindevice) {
+                                            let len = subdevice.io_raw().inputs().len();
+                                            if current_offset + len <= ETHERCAT_TX_RX_SIZE {
+                                                buffer[current_offset..current_offset + len]
+                                                    .copy_from_slice(subdevice.io_raw().inputs());
+                                                current_offset += len;
+                                            } else {
+                                                break;
+                                            }
                                         }
+                                        self.input_producer.publish();                            
                                     }
-                                    self.input_producer.publish();
-                                }
-                                None => {}
+                                    None => {}
                             }
 
                             if self.cycle.load(Relaxed) == u64::MAX {

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -541,30 +541,27 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                         };
 
                         let mut is_all_op = false;
-                        let mut not_all_op_cycles: u32 = 0;    
-                        let mut no_outputs: usize = 0;                    
+                        let mut not_all_op_cycles: u32 = 0;
                         loop {
-                            let cycle_start = Instant::now();
                             match self.output_consumer.read() {
-                                    Some(full_buffer) => {
-                                        let mut current_offset = 0;
-                                            for subdevice in group.iter(&maindevice) {
-                                                let mut output = subdevice.outputs_raw_mut();
-                                                let len = output.len();
-                                                output.copy_from_slice(
-                                                            &full_buffer[current_offset..current_offset + len],
-                                                );
-                                                current_offset += len;
-                                            }
+                                Some(full_buffer) => {
+                                    let mut current_offset = 0;
+                                    for subdevice in group.iter(&maindevice) {
+                                        let mut output = subdevice.outputs_raw_mut();
+                                        let len = output.len();
+                                        output.copy_from_slice(
+                                            &full_buffer[current_offset..current_offset + len],
+                                        );
+                                        current_offset += len;
+                                    }
                                     self.output_consumer.finish_read();
                                 }
-                                None => {                                                                    
-                                }
+                                None => {}
                             };
-
-                            let res = group.tx_rx_dc(&maindevice).await.expect("TX_RX Failed");                            
+                            let cycle_start = Instant::now();
+                            let res = group.tx_rx_dc(&maindevice).await.expect("TX_RX Failed");
                             self.dc_system_time_ns
-                                .store(res.extra.dc_system_time, Relaxed);                            
+                                .store(res.extra.dc_system_time, Relaxed);
                             self.next_cycle = cycle_start + res.extra.next_cycle_wait;
 
                             if !is_all_op {
@@ -621,23 +618,23 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                                 }
                             }
 
-                             match self.input_producer.input_buffer_mut() {
+                            match self.input_producer.input_buffer_mut() {
                                 Some(buffer) => {
-                                        // We get a mutable slice to the whole buffer to make sub-slicing easier
-                                        let mut current_offset = 0;
-                                        for subdevice in group.iter(&maindevice) {
-                                            let len = subdevice.io_raw().inputs().len();
-                                            if current_offset + len <= ETHERCAT_TX_RX_SIZE {
-                                                buffer[current_offset..current_offset + len]
-                                                    .copy_from_slice(subdevice.io_raw().inputs());
-                                                current_offset += len;
-                                            } else {
-                                                break;
-                                            }
+                                    // We get a mutable slice to the whole buffer to make sub-slicing easier
+                                    let mut current_offset = 0;
+                                    for subdevice in group.iter(&maindevice) {
+                                        let len = subdevice.io_raw().inputs().len();
+                                        if current_offset + len <= ETHERCAT_TX_RX_SIZE {
+                                            buffer[current_offset..current_offset + len]
+                                                .copy_from_slice(subdevice.io_raw().inputs());
+                                            current_offset += len;
+                                        } else {
+                                            break;
                                         }
-                                        self.input_producer.publish();                            
                                     }
-                                    None => {}
+                                    self.input_producer.publish();
+                                }
+                                None => {}
                             }
 
                             if self.cycle.load(Relaxed) == u64::MAX {

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -622,12 +622,8 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                                 None => {}
                             }
 
-                            if self.cycle.load(Relaxed) == u64::MAX {
-                                self.cycle.store(0, Relaxed);
-                            } else {
-                                self.cycle.fetch_add(1, Relaxed);
-                            }
-
+                            // This gives the client side time to look at the inputs and write outputs
+                            // Might be a bit too tight if running < 125us but at that point it isnt really stable anyways
                             spinner.sleep_until(self.next_cycle - Duration::from_micros(10));
                             match self.output_consumer.read() {
                                 Some(full_buffer) => {
@@ -644,10 +640,15 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                                 }
                                 None => {}
                             };
+                            // Sleep the rest of the deadline
                             spinner.sleep_until(self.next_cycle);
+                            if self.cycle.load(Relaxed) == u64::MAX {
+                                self.cycle.store(0, Relaxed);
+                            } else {
+                                self.cycle.fetch_add(1, Relaxed);
+                            }
                             self.cycle_time_us
                                 .store(cycle_start.elapsed().as_micros() as u64, Relaxed);
-
                         }
                     });
                 }

--- a/ethercat_hal/src/lib.rs
+++ b/ethercat_hal/src/lib.rs
@@ -349,9 +349,9 @@ where
     pub join_handle: Option<JoinHandle<Result<(), anyhow::Error>>>,
 }
 
-pub type StandardEtherCATAppHandle = EtherCATAppHandle<TripleBufConsumer, TripleBufProducer>;
-pub type MockEtherCATAppHandle = EtherCATAppHandle<MockConsumer, MockProducer>;
-pub type StandardEtherCATController = EtherCATController<TripleBufConsumer, TripleBufProducer>;
+pub type StdEcatHandle = EtherCATAppHandle<Arc<Mailbox>, Arc<Mailbox>>;
+pub type MockEcatHandle = EtherCATAppHandle<MockConsumer, MockProducer>;
+pub type StdEcatController = EtherCATController<Arc<Mailbox>, Arc<Mailbox>>;
 
 /*Metadata for a Subdevice Contains start and end of the given subdevices pdu*/
 #[derive(Clone, Copy, Debug)]
@@ -740,7 +740,7 @@ pub fn init_ethercat(
     };
 
     let app_handle = EtherCATAppHandle {
-        input_consumer:  mailbox2,
+        input_consumer: mailbox2,
         output_producer: mailbox,
         cycle,
         cycle_time_us,

--- a/ethercat_hal/src/lib.rs
+++ b/ethercat_hal/src/lib.rs
@@ -687,18 +687,17 @@ impl Default for MasterConfiguration {
 pub fn init_ethercat(
     interface_name: &str,
     config: Option<MasterConfiguration>,
-) -> EtherCATControl<TripleBufConsumer, Arc<Mailbox>> {
+) -> EtherCATControl<Arc<Mailbox>, Arc<Mailbox>> {
     use std::sync::atomic::AtomicU8;
-
     let (tx, rx) = mpsc::channel();
-    let (input_producer, input_consumer) =
-        triple_buffer::triple_buffer(&[0u8; ETHERCAT_TX_RX_SIZE]);
-
     let mailbox = Arc::new(Mailbox {
         data: [0u8; ETHERCAT_TX_RX_SIZE].into(),
         full: AtomicBool::new(false),
     });
-
+    let mailbox2 = Arc::new(Mailbox {
+        data: [0u8; ETHERCAT_TX_RX_SIZE].into(),
+        full: AtomicBool::new(false),
+    });
     let cycle: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
     let cycle_time_us: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
     let next_cycle_us: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
@@ -711,9 +710,7 @@ pub fn init_ethercat(
 
     let mut controller = match config {
         Some(conf) => EtherCATController::new(
-            TripleBufProducer {
-                output_producer: input_producer,
-            },
+            mailbox2.clone(),
             mailbox.clone(),
             rx,
             Some(interface_name.to_string()),
@@ -727,9 +724,7 @@ pub fn init_ethercat(
             all_op.clone(),
         ),
         None => EtherCATController::new(
-            TripleBufProducer {
-                output_producer: input_producer,
-            },
+            mailbox2.clone(),
             mailbox.clone(),
             rx,
             Some(interface_name.to_string()),
@@ -745,7 +740,7 @@ pub fn init_ethercat(
     };
 
     let app_handle = EtherCATAppHandle {
-        input_consumer: TripleBufConsumer { input_consumer },
+        input_consumer:  mailbox2,
         output_producer: mailbox,
         cycle,
         cycle_time_us,

--- a/examples/rt.rs
+++ b/examples/rt.rs
@@ -91,10 +91,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _res = ethercat_interface.request_state_change(EtherCATState::Op);
     std::thread::sleep(Duration::from_millis(5000));
 
+    let mut missed_frames : usize = 0;
+
     while cycles_recorded < total_cycles {
         // Spin until io thread has advanced past our last seen cycle
         while last_cycle == ethercat_control.app_handle.get_current_cycle() {}
-        let current_controller_cycle = ethercat_control.app_handle.get_current_cycle();
+        let current_controller_cycle = ethercat_control.app_handle.get_current_cycle();        
         if current_controller_cycle > last_cycle {
             last_cycle = current_controller_cycle;
             let cycle_time = ethercat_control.app_handle.get_cycle_time_us();
@@ -102,6 +104,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let jitter = (cycle_time as i64 - cycle_time_us as i64).abs() as u64;
             jitters[cycles_recorded] = jitter;
             cycles_recorded += 1;
+        } else if current_controller_cycle < last_cycle {
+            // Monotonicity is broken (cycle went backwards or wrapped around)
+            missed_frames += 1;
+            // Strategy choice: Either update last_cycle to prevent an infinite loop,
+            // or leave it if you expect the hardware/driver to correct itself.
+            last_cycle = current_controller_cycle; 
         }
     }
 
@@ -149,6 +157,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("  Max:                {} µs", max_time);
     println!("  Std Dev:            {:.2} µs", std_dev);
     println!("  99th Percentile:    {} µs", p99_time);
+    println!("  Missing Frames:                {}", missed_frames);
     println!("---------------------------------------------------");
     println!("Jitter Metrics (Deviation from Target):");
     println!("  99th Pct Jitter:    {} µs", p99_jitter);

--- a/examples/rt.rs
+++ b/examples/rt.rs
@@ -1,28 +1,40 @@
 use ethercat_hal::{
-    DcConfiguration, EtherCATState, MasterConfiguration, RtOptimizationConfig, init_ethercat, set_current_thread_rt_priority,
+    DcConfiguration, EtherCATState, EtherCATThreadChannel, MasterConfiguration, RtOptimizationConfig, StdEcatHandle, init_ethercat, set_current_thread_rt_priority,
 };
 use std::fs::File;
 use std::io::Write;
 use std::{env, time::Duration};
+struct Setup {
+    pub total_cycles : usize,
+    pub cycle_time_us : u64,
+    pub ec_interface : Option<StdEcatHandle>,
+    pub ec_config_interface : Option<EtherCATThreadChannel>,
+}
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let interface = env::args().nth(1).expect("No Interface-name given");
-    let cycle_time_us: u64 = env::args()
-        .nth(2)
-        .expect("No Target Cycle time given")
-        .parse()
-        .expect("Target Cycle time must be a valid number");
+fn setup() -> Setup {
+    let interface =    env::args()
+        .nth(1)
+        .expect("No Interface given");
+    let mut setup : Setup = 
+        Setup {
+            cycle_time_us:  env::args()
+            .nth(2)
+            .expect("No Target Cycle time given")
+            .parse()
+            .expect("Target Cycle time must be a valid number"),
 
-    let total_cycles: usize = env::args()
-        .nth(3)
-        .expect("No total_cycles given")
-        .parse()
-        .expect("total_cycles must be a valid number");
-
+            total_cycles: env::args()
+            .nth(3)
+            .expect("No total_cycles given")
+            .parse()
+            .expect("total_cycles must be a valid number"),
+            ec_interface : None,
+            ec_config_interface: None
+        };
     let mut dc_config = DcConfiguration::default();
     dc_config.start_delay = Duration::from_millis(100);
-    dc_config.sync0_period = Duration::from_micros(cycle_time_us);
-    dc_config.sync0_shift = Duration::from_micros(cycle_time_us / 2);
+    dc_config.sync0_period = Duration::from_micros(setup.cycle_time_us);
+    dc_config.sync0_shift = Duration::from_micros(setup.cycle_time_us / 2);
     dc_config.target_dc_tick = 500;
 
     /*
@@ -40,59 +52,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let config = MasterConfiguration {
-        target_cycle_time_us: cycle_time_us as usize,
+        target_cycle_time_us: setup.cycle_time_us as usize,
         tx_rx_config: ethercat_hal::MasterTxRxConfig::TxRxIoUring,
         dc_config,
         realtime_optimizations: Some(rt),
         wkc_mismatch_threshold: 5,
         op_ramp_grace_cycles: 10000,
     };
+    let ethercat_control = init_ethercat(&interface, Some(config));
+    setup.ec_interface = Some(ethercat_control.app_handle);
+    setup.ec_config_interface = Some(ethercat_control.channel);
+    return setup;
+}
 
-    let mut ethercat_control = init_ethercat(&interface, Some(config));
-    let ethercat_interface = ethercat_control.channel;
-
-    // Rust is playing smart here
-    // and doesnt actually touch any pages here (on linux)
-    let mut cycle_times = vec![0u64; total_cycles];
-    let mut jitters = vec![0u64; total_cycles];
-    let mut last_cycle = 0;
-    let mut cycles_recorded = 0;
-
-    // Make sure that every index is written to, so that the pages are HOT
-    for val in cycle_times.iter_mut() {
+// Make sure that every index is written to, so that the pages are HOT, meaning they are actually allocated in RAM
+fn warm_up_memory(vec : &mut Vec<u64> ){
+    for val in vec.iter_mut() {
         *val = 0;
     }
+}
 
-    for val in jitters.iter_mut() {
-        *val = 0;
-    }
-
-    let _res = ethercat_interface.request_state_change(EtherCATState::PreOp);
-    std::thread::sleep(Duration::from_millis(5000));
-
-    println!(
-        "found {:?} ethercat terminals: ",
-        ethercat_control.app_handle.get_subdevice_count()
-    );
-
-    let subdevices = ethercat_control
-        .app_handle
-        .try_get_subdevices_vec_sync()
-        .unwrap();
-
-    for i in 0..ethercat_control.app_handle.get_subdevice_count() {
-        println!("{:?}", subdevices[i as usize].get_name());
-        let addr = subdevices[i as usize].device_address;
-        if subdevices[i as usize].get_name().unwrap() != "EL4008" {
-            ethercat_interface.enable_dc_sync0(addr).unwrap();
-        }
-    }
-
-    let _res = ethercat_interface.request_state_change(EtherCATState::Op);
-    std::thread::sleep(Duration::from_millis(5000));
-    let mut missed_frames : usize = 0;
-
-
+fn apply_rt(){
+    /*
+        Run The Client loop with max prio, on isolated core 2
+    */
     let id = core_affinity::CoreId {
         id: 2,
     };
@@ -101,15 +84,73 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     core_affinity::set_for_current(id);
   
-    while cycles_recorded < total_cycles {        
-        while ethercat_control.app_handle.write_outputs().is_none() {}        
-        let t = ethercat_control.app_handle.write_outputs().unwrap();
-        t[0] = 0;
-        ethercat_control.app_handle.send_outputs();
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let setup = setup();
+    let total_cycles = setup.total_cycles;
+    let ec_config_interface = setup.ec_config_interface.unwrap();
+    let mut ec_app_interface = setup.ec_interface.unwrap();
+    
+    // Rust is playing smart here
+    // and doesnt actually touch any pages here (on linux)
+    let mut cycle_times = vec![0u64; total_cycles];
+    let mut jitters = vec![0u64; total_cycles];
+    let mut last_cycle = 0;
+    let mut cycles_recorded = 0;
+    let mut missed_frames : usize = 0;
+    
+    warm_up_memory(&mut cycle_times);
+    warm_up_memory(&mut jitters);
+
+    let _res = ec_config_interface.request_state_change(EtherCATState::PreOp);
+    std::thread::sleep(Duration::from_millis(5000));
+
+    println!(
+        "found {:?} ethercat terminals: ",
+        ec_app_interface.get_subdevice_count()
+    );
+
+    let subdevices = ec_app_interface
+        .try_get_subdevices_vec_sync()
+        .unwrap();
+
+    for i in 0..ec_app_interface.get_subdevice_count() {
+        println!("{:?}", subdevices[i as usize].get_name());
+        let addr = subdevices[i as usize].device_address;
+        if subdevices[i as usize].get_name().unwrap() != "EL4008" {
+            ec_config_interface.enable_dc_sync0(addr).unwrap();
+        }
+    }
+    let _res = ec_config_interface.request_state_change(EtherCATState::Op);
+    std::thread::sleep(Duration::from_millis(5000));
+    
+    apply_rt();
+
+    let _op_subdevices = ec_app_interface
+        .try_get_subdevices_vec_sync()
+        .unwrap();
+
+
+    // Due to the startup logic missed frames is always at least one here ...
+    // Even though no frame was actually missed. For more accurate logic the counter of missed_frames
+    // should be moved to the controller logic
+    while cycles_recorded < total_cycles {
+
+        while ec_app_interface.get_inputs().is_none() {}
+        let _inputs = ec_app_interface.get_inputs().unwrap();
+        // Do something with the inputs here
+        // ... 
+        ec_app_interface.finish_read();
+
+        while ec_app_interface.write_outputs().is_none() {}        
+        let outputs = ec_app_interface.write_outputs().unwrap();
+        outputs[0] = 0;
+        ec_app_interface.send_outputs();
         
         // Spin until io thread has advanced past our last seen cycle
         //while last_cycle == ethercat_control.app_handle.get_current_cycle() {}
-        let current_controller_cycle = ethercat_control.app_handle.get_current_cycle();
+        let current_controller_cycle = ec_app_interface.get_current_cycle();
 	if last_cycle != 0 { 
 	    if current_controller_cycle - last_cycle > 1 {
 	        missed_frames += (current_controller_cycle - last_cycle - 1) as usize;
@@ -121,9 +162,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         if current_controller_cycle > last_cycle {
             last_cycle = current_controller_cycle;
-            let cycle_time = ethercat_control.app_handle.get_cycle_time_us();
+            let cycle_time = ec_app_interface.get_cycle_time_us();
             cycle_times[cycles_recorded] = cycle_time;
-            let jitter = (cycle_time as i64 - cycle_time_us as i64).abs() as u64;
+            let jitter = (cycle_time as i64 - setup.cycle_time_us as i64).abs() as u64;
             jitters[cycles_recorded] = jitter;
             cycles_recorded += 1;
         }
@@ -164,7 +205,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     file.write_all(json_string.as_bytes())?;
 
     println!("\n================ BENCHMARK RESULTS ================");
-    println!("Target Cycle Time:    {} µs", cycle_time_us);
+    println!("Target Cycle Time:    {} µs", setup.cycle_time_us);
     println!("Total Cycles Run:     {}", total_cycles);
     println!("---------------------------------------------------");
     println!("Cycle Time Metrics:");

--- a/examples/rt.rs
+++ b/examples/rt.rs
@@ -120,7 +120,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let _op_subdevices = ec_app_interface.try_get_subdevices_vec_sync().unwrap();
 
-    // Due to the startup logic missed frames is always at least one here ...
     // Even though no frame was actually missed. For more accurate logic the counter of missed_frames
     // should be moved to the controller logic
     while cycles_recorded < total_cycles {
@@ -142,9 +141,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             if current_controller_cycle - last_cycle > 1 {
                 missed_frames += (current_controller_cycle - last_cycle - 1) as usize;
             }
-        }
-        if current_controller_cycle - last_cycle > 1 {
-            missed_frames += 1;
         }
 
         if current_controller_cycle > last_cycle {
@@ -190,6 +186,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let json_string = format!("{:?}", cycle_times);
     let mut file = File::create("/tmp/output.json")?;
     file.write_all(json_string.as_bytes())?;
+
+    // Due to the startup logic missed frames is always at least one here not entirely sure why?
+    // will be decremented by one at the end and also it isnt actually a missed frame, just one 
+
 
     println!("\n================ BENCHMARK RESULTS ================");
     println!("Target Cycle Time:    {} µs", setup.cycle_time_us);

--- a/examples/rt.rs
+++ b/examples/rt.rs
@@ -5,6 +5,7 @@ use ethercat_hal::{
 use std::fs::File;
 use std::io::Write;
 use std::{env, time::Duration};
+
 struct Setup {
     pub total_cycles: usize,
     pub cycle_time_us: u64,
@@ -70,13 +71,32 @@ fn warm_up_memory(vec: &mut Vec<u64>) {
     }
 }
 
+//  Run The Client loop with max prio, on isolated core 2
 fn apply_rt() {
-    /*
-        Run The Client loop with max prio, on isolated core 2
-    */
     let id = core_affinity::CoreId { id: 2 };
     set_current_thread_rt_priority(99);
     core_affinity::set_for_current(id);
+}
+
+fn move_to_op(ec_config_interface: &EtherCATThreadChannel, ec_app_interface: &StdEcatHandle) {
+    let _res = ec_config_interface.request_state_change(EtherCATState::PreOp);
+    std::thread::sleep(Duration::from_millis(5000));
+
+    println!(
+        "found {:?} ethercat terminals: ",
+        ec_app_interface.get_subdevice_count()
+    );
+
+    let subdevices = ec_app_interface.try_get_subdevices_vec_sync().unwrap();
+    for i in 0..ec_app_interface.get_subdevice_count() {
+        println!("{:?}", subdevices[i as usize].get_name());
+        let addr = subdevices[i as usize].device_address;
+        if subdevices[i as usize].get_name().unwrap() != "EL4008" {
+            ec_config_interface.enable_dc_sync0(addr).unwrap();
+        }
+    }
+    let _res = ec_config_interface.request_state_change(EtherCATState::Op);
+    std::thread::sleep(Duration::from_millis(5000));
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -95,30 +115,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     warm_up_memory(&mut cycle_times);
     warm_up_memory(&mut jitters);
-
-    let _res = ec_config_interface.request_state_change(EtherCATState::PreOp);
-    std::thread::sleep(Duration::from_millis(5000));
-
-    println!(
-        "found {:?} ethercat terminals: ",
-        ec_app_interface.get_subdevice_count()
-    );
-
-    let subdevices = ec_app_interface.try_get_subdevices_vec_sync().unwrap();
-
-    for i in 0..ec_app_interface.get_subdevice_count() {
-        println!("{:?}", subdevices[i as usize].get_name());
-        let addr = subdevices[i as usize].device_address;
-        if subdevices[i as usize].get_name().unwrap() != "EL4008" {
-            ec_config_interface.enable_dc_sync0(addr).unwrap();
-        }
-    }
-    let _res = ec_config_interface.request_state_change(EtherCATState::Op);
-    std::thread::sleep(Duration::from_millis(5000));
-
+    move_to_op(&ec_config_interface, &ec_app_interface);
+    //let op_subdevices = ec_app_interface.try_get_subdevices_vec_sync().unwrap();
     apply_rt();
-
-    let _op_subdevices = ec_app_interface.try_get_subdevices_vec_sync().unwrap();
 
     // Even though no frame was actually missed. For more accurate logic the counter of missed_frames
     // should be moved to the controller logic
@@ -135,7 +134,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ec_app_interface.send_outputs();
 
         // Spin until io thread has advanced past our last seen cycle
-        //while last_cycle == ethercat_control.app_handle.get_current_cycle() {}
         let current_controller_cycle = ec_app_interface.get_current_cycle();
         if last_cycle != 0 {
             if current_controller_cycle - last_cycle > 1 {
@@ -186,10 +184,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let json_string = format!("{:?}", cycle_times);
     let mut file = File::create("/tmp/output.json")?;
     file.write_all(json_string.as_bytes())?;
-
-    // Due to the startup logic missed frames is always at least one here not entirely sure why?
-    // will be decremented by one at the end and also it isnt actually a missed frame, just one 
-
 
     println!("\n================ BENCHMARK RESULTS ================");
     println!("Target Cycle Time:    {} µs", setup.cycle_time_us);

--- a/examples/rt.rs
+++ b/examples/rt.rs
@@ -1,5 +1,5 @@
 use ethercat_hal::{
-    DcConfiguration, EtherCATState, MasterConfiguration, RtOptimizationConfig, init_ethercat,
+    DcConfiguration, EtherCATState, MasterConfiguration, RtOptimizationConfig, init_ethercat, set_current_thread_rt_priority,
 };
 use std::fs::File;
 use std::io::Write;
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         op_ramp_grace_cycles: 10000,
     };
 
-    let ethercat_control = init_ethercat(&interface, Some(config));
+    let mut ethercat_control = init_ethercat(&interface, Some(config));
     let ethercat_interface = ethercat_control.channel;
 
     // Rust is playing smart here
@@ -90,13 +90,35 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let _res = ethercat_interface.request_state_change(EtherCATState::Op);
     std::thread::sleep(Duration::from_millis(5000));
-
     let mut missed_frames : usize = 0;
 
-    while cycles_recorded < total_cycles {
+
+    let id = core_affinity::CoreId {
+        id: 2,
+    };
+    set_current_thread_rt_priority(
+        99,
+    );
+    core_affinity::set_for_current(id);
+  
+    while cycles_recorded < total_cycles {        
+        while ethercat_control.app_handle.write_outputs().is_none() {}        
+        let t = ethercat_control.app_handle.write_outputs().unwrap();
+        t[0] = 0;
+        ethercat_control.app_handle.send_outputs();
+        
         // Spin until io thread has advanced past our last seen cycle
-        while last_cycle == ethercat_control.app_handle.get_current_cycle() {}
-        let current_controller_cycle = ethercat_control.app_handle.get_current_cycle();        
+        //while last_cycle == ethercat_control.app_handle.get_current_cycle() {}
+        let current_controller_cycle = ethercat_control.app_handle.get_current_cycle();
+	if last_cycle != 0 { 
+	    if current_controller_cycle - last_cycle > 1 {
+	        missed_frames += (current_controller_cycle - last_cycle - 1) as usize;
+	    }
+	}
+        if current_controller_cycle - last_cycle > 1 {
+            missed_frames += 1;
+        }
+
         if current_controller_cycle > last_cycle {
             last_cycle = current_controller_cycle;
             let cycle_time = ethercat_control.app_handle.get_cycle_time_us();
@@ -104,12 +126,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let jitter = (cycle_time as i64 - cycle_time_us as i64).abs() as u64;
             jitters[cycles_recorded] = jitter;
             cycles_recorded += 1;
-        } else if current_controller_cycle < last_cycle {
-            // Monotonicity is broken (cycle went backwards or wrapped around)
-            missed_frames += 1;
-            // Strategy choice: Either update last_cycle to prevent an infinite loop,
-            // or leave it if you expect the hardware/driver to correct itself.
-            last_cycle = current_controller_cycle; 
         }
     }
 

--- a/examples/rt.rs
+++ b/examples/rt.rs
@@ -1,36 +1,34 @@
 use ethercat_hal::{
-    DcConfiguration, EtherCATState, EtherCATThreadChannel, MasterConfiguration, RtOptimizationConfig, StdEcatHandle, init_ethercat, set_current_thread_rt_priority,
+    DcConfiguration, EtherCATState, EtherCATThreadChannel, MasterConfiguration,
+    RtOptimizationConfig, StdEcatHandle, init_ethercat, set_current_thread_rt_priority,
 };
 use std::fs::File;
 use std::io::Write;
 use std::{env, time::Duration};
 struct Setup {
-    pub total_cycles : usize,
-    pub cycle_time_us : u64,
-    pub ec_interface : Option<StdEcatHandle>,
-    pub ec_config_interface : Option<EtherCATThreadChannel>,
+    pub total_cycles: usize,
+    pub cycle_time_us: u64,
+    pub ec_interface: Option<StdEcatHandle>,
+    pub ec_config_interface: Option<EtherCATThreadChannel>,
 }
 
 fn setup() -> Setup {
-    let interface =    env::args()
-        .nth(1)
-        .expect("No Interface given");
-    let mut setup : Setup = 
-        Setup {
-            cycle_time_us:  env::args()
+    let interface = env::args().nth(1).expect("No Interface given");
+    let mut setup: Setup = Setup {
+        cycle_time_us: env::args()
             .nth(2)
             .expect("No Target Cycle time given")
             .parse()
             .expect("Target Cycle time must be a valid number"),
 
-            total_cycles: env::args()
+        total_cycles: env::args()
             .nth(3)
             .expect("No total_cycles given")
             .parse()
             .expect("total_cycles must be a valid number"),
-            ec_interface : None,
-            ec_config_interface: None
-        };
+        ec_interface: None,
+        ec_config_interface: None,
+    };
     let mut dc_config = DcConfiguration::default();
     dc_config.start_delay = Duration::from_millis(100);
     dc_config.sync0_period = Duration::from_micros(setup.cycle_time_us);
@@ -66,24 +64,19 @@ fn setup() -> Setup {
 }
 
 // Make sure that every index is written to, so that the pages are HOT, meaning they are actually allocated in RAM
-fn warm_up_memory(vec : &mut Vec<u64> ){
+fn warm_up_memory(vec: &mut Vec<u64>) {
     for val in vec.iter_mut() {
         *val = 0;
     }
 }
 
-fn apply_rt(){
+fn apply_rt() {
     /*
         Run The Client loop with max prio, on isolated core 2
     */
-    let id = core_affinity::CoreId {
-        id: 2,
-    };
-    set_current_thread_rt_priority(
-        99,
-    );
+    let id = core_affinity::CoreId { id: 2 };
+    set_current_thread_rt_priority(99);
     core_affinity::set_for_current(id);
-  
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -91,15 +84,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let total_cycles = setup.total_cycles;
     let ec_config_interface = setup.ec_config_interface.unwrap();
     let mut ec_app_interface = setup.ec_interface.unwrap();
-    
+
     // Rust is playing smart here
     // and doesnt actually touch any pages here (on linux)
     let mut cycle_times = vec![0u64; total_cycles];
     let mut jitters = vec![0u64; total_cycles];
     let mut last_cycle = 0;
     let mut cycles_recorded = 0;
-    let mut missed_frames : usize = 0;
-    
+    let mut missed_frames: usize = 0;
+
     warm_up_memory(&mut cycle_times);
     warm_up_memory(&mut jitters);
 
@@ -111,9 +104,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ec_app_interface.get_subdevice_count()
     );
 
-    let subdevices = ec_app_interface
-        .try_get_subdevices_vec_sync()
-        .unwrap();
+    let subdevices = ec_app_interface.try_get_subdevices_vec_sync().unwrap();
 
     for i in 0..ec_app_interface.get_subdevice_count() {
         println!("{:?}", subdevices[i as usize].get_name());
@@ -124,38 +115,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     let _res = ec_config_interface.request_state_change(EtherCATState::Op);
     std::thread::sleep(Duration::from_millis(5000));
-    
+
     apply_rt();
 
-    let _op_subdevices = ec_app_interface
-        .try_get_subdevices_vec_sync()
-        .unwrap();
-
+    let _op_subdevices = ec_app_interface.try_get_subdevices_vec_sync().unwrap();
 
     // Due to the startup logic missed frames is always at least one here ...
     // Even though no frame was actually missed. For more accurate logic the counter of missed_frames
     // should be moved to the controller logic
     while cycles_recorded < total_cycles {
-
         while ec_app_interface.get_inputs().is_none() {}
         let _inputs = ec_app_interface.get_inputs().unwrap();
         // Do something with the inputs here
-        // ... 
+        // ...
         ec_app_interface.finish_read();
 
-        while ec_app_interface.write_outputs().is_none() {}        
+        while ec_app_interface.write_outputs().is_none() {}
         let outputs = ec_app_interface.write_outputs().unwrap();
         outputs[0] = 0;
         ec_app_interface.send_outputs();
-        
+
         // Spin until io thread has advanced past our last seen cycle
         //while last_cycle == ethercat_control.app_handle.get_current_cycle() {}
         let current_controller_cycle = ec_app_interface.get_current_cycle();
-	if last_cycle != 0 { 
-	    if current_controller_cycle - last_cycle > 1 {
-	        missed_frames += (current_controller_cycle - last_cycle - 1) as usize;
-	    }
-	}
+        if last_cycle != 0 {
+            if current_controller_cycle - last_cycle > 1 {
+                missed_frames += (current_controller_cycle - last_cycle - 1) as usize;
+            }
+        }
         if current_controller_cycle - last_cycle > 1 {
             missed_frames += 1;
         }
@@ -214,7 +201,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("  Max:                {} µs", max_time);
     println!("  Std Dev:            {:.2} µs", std_dev);
     println!("  99th Percentile:    {} µs", p99_time);
-    println!("  Missing Frames:                {}", missed_frames);
+    println!("  Missing Frames:     {}", missed_frames);
     println!("---------------------------------------------------");
     println!("Jitter Metrics (Deviation from Target):");
     println!("  99th Pct Jitter:    {} µs", p99_jitter);


### PR DESCRIPTION
This makes sure there is a pipeline of tx_rx -> inputs -> wait until next cycle - some_processing_time -> write outputs supplied by client -> Wait rest of deadline -> tx_rx

This is needed if the client always wants to see all inputs and always write the outputs. However for a fully synchronized