### PR TITLE
Functional oversampling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "ethercrab"
 version = "0.7.1"
-source = "git+https://github.com/kraemr/ethercrab?branch=main#471bc90a70f5878dc45a57722e51cbc2753b4e29"
+source = "git+https://github.com/kraemr/ethercrab?rev=c75c8c03fdf7f8ed8de5dfaf41a7e3e9d47afd81#c75c8c03fdf7f8ed8de5dfaf41a7e3e9d47afd81"
 dependencies = [
  "async-io",
  "atomic-waker",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "ethercrab-wire"
 version = "0.3.0"
-source = "git+https://github.com/kraemr/ethercrab?branch=main#471bc90a70f5878dc45a57722e51cbc2753b4e29"
+source = "git+https://github.com/kraemr/ethercrab?rev=c75c8c03fdf7f8ed8de5dfaf41a7e3e9d47afd81#c75c8c03fdf7f8ed8de5dfaf41a7e3e9d47afd81"
 dependencies = [
  "ethercrab-wire-derive",
  "heapless 0.8.0",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "ethercrab-wire-derive"
 version = "0.3.0"
-source = "git+https://github.com/kraemr/ethercrab?branch=main#471bc90a70f5878dc45a57722e51cbc2753b4e29"
+source = "git+https://github.com/kraemr/ethercrab?rev=c75c8c03fdf7f8ed8de5dfaf41a7e3e9d47afd81#c75c8c03fdf7f8ed8de5dfaf41a7e3e9d47afd81"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,18 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,12 +235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,58 +255,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
-name = "clap"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
-dependencies = [
- "clap_builder",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
-dependencies = [
- "anstyle",
- "clap_lex",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"
@@ -396,40 +326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools",
- "num-traits",
- "once_cell",
- "oorandom",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools",
-]
-
-[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,12 +336,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "deluxe"
@@ -496,12 +386,6 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
-
-[[package]]
-name = "either"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embassy-time"
@@ -646,7 +530,7 @@ dependencies = [
 [[package]]
 name = "ethercrab"
 version = "0.7.1"
-source = "git+https://github.com/ethercrab-rs/ethercrab?branch=main#4c7d36157fa5caab3194df494e92e08551cd2e43"
+source = "git+https://github.com/kraemr/ethercrab?branch=main#471bc90a70f5878dc45a57722e51cbc2753b4e29"
 dependencies = [
  "async-io",
  "atomic-waker",
@@ -676,7 +560,7 @@ dependencies = [
 [[package]]
 name = "ethercrab-wire"
 version = "0.3.0"
-source = "git+https://github.com/ethercrab-rs/ethercrab?branch=main#4c7d36157fa5caab3194df494e92e08551cd2e43"
+source = "git+https://github.com/kraemr/ethercrab?branch=main#471bc90a70f5878dc45a57722e51cbc2753b4e29"
 dependencies = [
  "ethercrab-wire-derive",
  "heapless 0.8.0",
@@ -685,9 +569,8 @@ dependencies = [
 [[package]]
 name = "ethercrab-wire-derive"
 version = "0.3.0"
-source = "git+https://github.com/ethercrab-rs/ethercrab?branch=main#4c7d36157fa5caab3194df494e92e08551cd2e43"
+source = "git+https://github.com/kraemr/ethercrab?branch=main#471bc90a70f5878dc45a57722e51cbc2753b4e29"
 dependencies = [
- "criterion",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -846,17 +729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
-
-[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,32 +833,6 @@ checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itoa"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
@@ -1182,12 +1028,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "parking"
@@ -1452,15 +1292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,19 +1342,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.2",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.150"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
 ]
 
 [[package]]
@@ -1740,16 +1558,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "tokio"
 version = "1.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,16 +1732,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,15 +1761,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2162,9 +1951,3 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/ethercat_hal/Cargo.toml
+++ b/ethercat_hal/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.100"
-ethercrab = { git = "https://github.com/ethercrab-rs/ethercrab", branch = "main" }
+ethercrab = { git = "https://github.com/kraemr/ethercrab", branch = "main" }
 ethercat_hal_derive = { version = "0.1.0", path = "../ethercat_hal_derive" }
 units = { path = "../units" }
 bitvec = { version = "1.0.1", features = ["alloc"] }

--- a/ethercat_hal/Cargo.toml
+++ b/ethercat_hal/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.100"
-ethercrab = { git = "https://github.com/kraemr/ethercrab", branch = "main" }
+ethercrab = { git = "https://github.com/kraemr/ethercrab", rev = "c75c8c03fdf7f8ed8de5dfaf41a7e3e9d47afd81" }
 ethercat_hal_derive = { version = "0.1.0", path = "../ethercat_hal_derive" }
 units = { path = "../units" }
 bitvec = { version = "1.0.1", features = ["alloc"] }

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -650,7 +650,6 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                             // This gives the client side time to look at the inputs and write outputs
                             // Might be a bit too tight if running < 125us but at that point it isnt really stable anyways
                             spinner.sleep_until(self.next_cycle - Duration::from_nanos(10000));
-                            //println!("delta: {}, integral: {}, offsettime: {} time till next cycle {}", error, integral, offsettime,cycle_time_ns as u64 - offsettime as u64);
                             //println!("time {:?} delta: {}, integral: {}, offsettime: {} time till next cycle {}", cycle_start.elapsed() + Duration::from_nanos(10000),error, integral, offsettime,cycle_time_ns as u64 - offsettime as u64 );
                             match self.output_consumer.read() {
                                 Some(full_buffer) => {

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -650,7 +650,6 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                             // This gives the client side time to look at the inputs and write outputs
                             // Might be a bit too tight if running < 125us but at that point it isnt really stable anyways
                             spinner.sleep_until(self.next_cycle - Duration::from_nanos(10000));
-                            //println!("time {:?} delta: {}, integral: {}, offsettime: {} time till next cycle {}", cycle_start.elapsed() + Duration::from_nanos(10000),error, integral, offsettime,cycle_time_ns as u64 - offsettime as u64 );
                             match self.output_consumer.read() {
                                 Some(full_buffer) => {
                                     let mut current_offset = 0;

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -552,24 +552,23 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                         let pgain = 0.01 as f64;
                         let igain = 0.00002 as f64;
                         let sync_offset_ns: u64 =  500000;
-		        let mut offsettime : i64 = 0;
                         loop {
                             let cycle_start = Instant::now();
                             let res = group.tx_rx_dc(&maindevice).await.expect("TX_RX Failed");                         
                             delta =
                                 (res.extra.dc_system_time - sync_offset_ns) as i64 % cycle_time_ns;
-
                             if (delta > (cycle_time_ns / 2)) {
                                 delta = delta - cycle_time_ns
                             }
                             error = -delta;
+			    // Not sure what to clamp to, if at all Clamping seemed to have a negative effect? so just keep it as is
 			    integral = (integral + error);//.clamp(sync_offset_ns as i64*-1 * 10, sync_offset_ns as i64 * 10);
+			    // Maybe instead it makes sense to clamp offsettime?
                             let offsettime =
                                 ((error as f64 * pgain) + (integral as f64 * igain)) as i64;
                             self.dc_system_time_ns
                                 .store(res.extra.dc_system_time, Relaxed);
                             self.next_cycle = cycle_start + Duration::from_nanos(cycle_time_ns as u64 + offsettime as u64);
-
                             if !is_all_op {
                                 if res.all_op() {
                                     let mut subdevice_guard = self.subdevices.lock().await;

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -306,9 +306,16 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                             );
                             continue;
                         }
-                        ChannelRequests::ConfigureOversampling(device_address, oversampling_settings) => {
-                            let res =
-                                configure_oversampling(&mut preop_group, maindev, device_address,&oversampling_settings);
+                        ChannelRequests::ConfigureOversampling(
+                            device_address,
+                            oversampling_settings,
+                        ) => {
+                            let res = configure_oversampling(
+                                &mut preop_group,
+                                maindev,
+                                device_address,
+                                &oversampling_settings,
+                            );
                             send_response(
                                 msg.response_channel,
                                 ChannelResponse::ConfigureOversamplingResponse(res),
@@ -549,24 +556,25 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                         let mut delta: i64;
                         let pgain = 0.01 as f64;
                         let igain = 0.00002 as f64;
-                        let sync_offset_ns: u64 =  500000;
+                        let sync_offset_ns: u64 = 500000;
                         loop {
                             let cycle_start = Instant::now();
-                            let res = group.tx_rx_dc(&maindevice).await.expect("TX_RX Failed");                         
+                            let res = group.tx_rx_dc(&maindevice).await.expect("TX_RX Failed");
                             delta =
                                 (res.extra.dc_system_time - sync_offset_ns) as i64 % cycle_time_ns;
                             if delta > (cycle_time_ns / 2) {
                                 delta = delta - cycle_time_ns
                             }
                             error = -delta;
-			                 // Not sure what to clamp to, if at all Clamping seemed to have a negative effect? so just keep it as is
-			                 integral = integral + error ;//.clamp(sync_offset_ns as i64*-1 * 10, sync_offset_ns as i64 * 10);
-			                 // Maybe instead it makes sense to clamp offsettime?
+                            // Not sure what to clamp to, if at all Clamping seemed to have a negative effect? so just keep it as is
+                            integral = integral + error; //.clamp(sync_offset_ns as i64*-1 * 10, sync_offset_ns as i64 * 10);
+                            // Maybe instead it makes sense to clamp offsettime?
                             let offsettime =
                                 ((error as f64 * pgain) + (integral as f64 * igain)) as i64;
                             self.dc_system_time_ns
                                 .store(res.extra.dc_system_time, Relaxed);
-                            self.next_cycle = cycle_start + Duration::from_nanos(cycle_time_ns as u64 + offsettime as u64);
+                            self.next_cycle = cycle_start
+                                + Duration::from_nanos(cycle_time_ns as u64 + offsettime as u64);
                             if !is_all_op {
                                 if res.all_op() {
                                     let mut subdevice_guard = self.subdevices.lock().await;
@@ -624,7 +632,7 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                                 Some(buffer) => {
                                     // We get a mutable slice to the whole buffer to make sub-slicing easier
                                     let mut current_offset = 0;
-                                    for subdevice in group.iter(&maindevice) {                                      
+                                    for subdevice in group.iter(&maindevice) {
                                         let len = subdevice.io_raw().inputs().len();
                                         if current_offset + len <= ETHERCAT_TX_RX_SIZE {
                                             buffer[current_offset..current_offset + len]
@@ -643,7 +651,7 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                             // Might be a bit too tight if running < 125us but at that point it isnt really stable anyways
                             spinner.sleep_until(self.next_cycle - Duration::from_nanos(10000));
                             //println!("delta: {}, integral: {}, offsettime: {} time till next cycle {}", error, integral, offsettime,cycle_time_ns as u64 - offsettime as u64);
-                            println!("time {:?} delta: {}, integral: {}, offsettime: {} time till next cycle {}", cycle_start.elapsed() + Duration::from_nanos(10000),error, integral, offsettime,cycle_time_ns as u64 - offsettime as u64 );
+                            //println!("time {:?} delta: {}, integral: {}, offsettime: {} time till next cycle {}", cycle_start.elapsed() + Duration::from_nanos(10000),error, integral, offsettime,cycle_time_ns as u64 - offsettime as u64 );
                             match self.output_consumer.read() {
                                 Some(full_buffer) => {
                                     let mut current_offset = 0;
@@ -657,9 +665,7 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                                     }
                                     self.output_consumer.finish_read();
                                 }
-                                None => {
-                                    println!("NO OUTpUtSt");
-                                }
+                                None => {}
                             };
                             if self.cycle.load(Relaxed) == u64::MAX {
                                 self.cycle.store(0, Relaxed);
@@ -669,7 +675,6 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                             self.cycle_time_us
                                 .store(cycle_start.elapsed().as_micros() as u64, Relaxed);
                             spinner.sleep_until(self.next_cycle);
-
                         }
                     });
                 }

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -1,4 +1,3 @@
-use crate::devices::beckhoff_modules::el4732::EL4732_PRODUCT_ID;
 use crate::ethercat_helpers::configure_oversampling;
 use crate::ethercat_helpers::enable_dc_sync01;
 use crate::{
@@ -307,9 +306,9 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                             );
                             continue;
                         }
-                        ChannelRequests::ConfigureOversampling(device_address) => {
+                        ChannelRequests::ConfigureOversampling(device_address, oversampling_settings) => {
                             let res =
-                                configure_oversampling(&mut preop_group, maindev, device_address);
+                                configure_oversampling(&mut preop_group, maindev, device_address,&oversampling_settings);
                             send_response(
                                 msg.response_channel,
                                 ChannelResponse::ConfigureOversamplingResponse(res),
@@ -544,7 +543,6 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
 
                         let mut is_all_op = false;
                         let mut not_all_op_cycles: u32 = 0;
-                        let mut roundtrip_time = Duration::from_micros(0);
                         let cycle_time_ns = self.current_config.target_cycle_time_us as i64 * 1000;
                         let mut integral: i64 = 0;
                         let mut error: i64;
@@ -557,13 +555,13 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                             let res = group.tx_rx_dc(&maindevice).await.expect("TX_RX Failed");                         
                             delta =
                                 (res.extra.dc_system_time - sync_offset_ns) as i64 % cycle_time_ns;
-                            if (delta > (cycle_time_ns / 2)) {
+                            if delta > (cycle_time_ns / 2) {
                                 delta = delta - cycle_time_ns
                             }
                             error = -delta;
-			    // Not sure what to clamp to, if at all Clamping seemed to have a negative effect? so just keep it as is
-			    integral = (integral + error);//.clamp(sync_offset_ns as i64*-1 * 10, sync_offset_ns as i64 * 10);
-			    // Maybe instead it makes sense to clamp offsettime?
+			                 // Not sure what to clamp to, if at all Clamping seemed to have a negative effect? so just keep it as is
+			                 integral = integral + error ;//.clamp(sync_offset_ns as i64*-1 * 10, sync_offset_ns as i64 * 10);
+			                 // Maybe instead it makes sense to clamp offsettime?
                             let offsettime =
                                 ((error as f64 * pgain) + (integral as f64 * igain)) as i64;
                             self.dc_system_time_ns
@@ -626,32 +624,7 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                                 Some(buffer) => {
                                     // We get a mutable slice to the whole buffer to make sub-slicing easier
                                     let mut current_offset = 0;
-                                    for subdevice in group.iter(&maindevice) {
-                                        /*                             	  	if (subdevice.identity().product_id == EL4732_PRODUCT_ID) {
-                                                                let next_sync1_ts = u32::from_le_bytes(
-                                                                    subdevice.io_raw().inputs()[0..4].try_into().unwrap()
-                                                                );
-                                                                let dc_time_32 = (res.extra.dc_system_time & 0xFFFF_FFFF) as u32;
-                                                                let time_until_sync1 = next_sync1_ts.wrapping_sub(dc_time_32);
-                                                                let error_ns = (time_until_sync1 as i32) - sync_offset_ns as i32;
-                                                                let phase_correction_ns = error_ns / 10;
-                                                                let base_cycle = Duration::from_nanos(cycle_time_ns as u64);
-
-                                                                let duration = if phase_correction_ns >= 0 {
-                                                                    base_cycle + Duration::from_nanos(phase_correction_ns as u64)
-                                                                } else {
-                                                                    let abs_corr = phase_correction_ns.unsigned_abs() as u64;
-                                                                    if abs_corr < cycle_time_ns as u64{
-                                                                    base_cycle - Duration::from_nanos(abs_corr)
-                                                                    }else{
-                                                                       Duration::from_nanos(0)
-                                                                   }
-                                        //						    base_cycle - Duration::from_nanos(abs_corr)
-                                                                };
-                                                                                        //println!("dcref32 {} next sync1 ts {} time until sync1 {} duration until sync1 in nanos {}",dc_time_32, next_sync1_ts, time_until_sync1,duration.as_nanos());
-                                                                self.next_cycle = cycle_start + duration;
-
-                                                            }*/
+                                    for subdevice in group.iter(&maindevice) {                                      
                                         let len = subdevice.io_raw().inputs().len();
                                         if current_offset + len <= ETHERCAT_TX_RX_SIZE {
                                             buffer[current_offset..current_offset + len]
@@ -669,7 +642,7 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                             // This gives the client side time to look at the inputs and write outputs
                             // Might be a bit too tight if running < 125us but at that point it isnt really stable anyways
                             spinner.sleep_until(self.next_cycle - Duration::from_nanos(10000));
-//                            println!("delta: {}, integral: {}, offsettime: {} time till next cycle {}", error, integral, offsettime,cycle_time_ns as u64 - offsettime as u64);
+                            //println!("delta: {}, integral: {}, offsettime: {} time till next cycle {}", error, integral, offsettime,cycle_time_ns as u64 - offsettime as u64);
                             println!("time {:?} delta: {}, integral: {}, offsettime: {} time till next cycle {}", cycle_start.elapsed() + Duration::from_nanos(10000),error, integral, offsettime,cycle_time_ns as u64 - offsettime as u64 );
                             match self.output_consumer.read() {
                                 Some(full_buffer) => {

--- a/ethercat_hal/src/controller.rs
+++ b/ethercat_hal/src/controller.rs
@@ -1,3 +1,4 @@
+use crate::devices::beckhoff_modules::el4732::EL4732_PRODUCT_ID;
 use crate::ethercat_helpers::configure_oversampling;
 use crate::ethercat_helpers::enable_dc_sync01;
 use crate::{
@@ -543,12 +544,31 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
 
                         let mut is_all_op = false;
                         let mut not_all_op_cycles: u32 = 0;
+                        let mut roundtrip_time = Duration::from_micros(0);
+                        let cycle_time_ns = self.current_config.target_cycle_time_us as i64 * 1000;
+                        let mut integral: i64 = 0;
+                        let mut error: i64;
+                        let mut delta: i64;
+                        let pgain = 0.01 as f64;
+                        let igain = 0.00002 as f64;
+                        let sync_offset_ns: u64 =  500000;
+		        let mut offsettime : i64 = 0;
                         loop {
                             let cycle_start = Instant::now();
-                            let res = group.tx_rx_dc(&maindevice).await.expect("TX_RX Failed");
+                            let res = group.tx_rx_dc(&maindevice).await.expect("TX_RX Failed");                         
+                            delta =
+                                (res.extra.dc_system_time - sync_offset_ns) as i64 % cycle_time_ns;
+
+                            if (delta > (cycle_time_ns / 2)) {
+                                delta = delta - cycle_time_ns
+                            }
+                            error = -delta;
+			    integral = (integral + error);//.clamp(sync_offset_ns as i64*-1 * 10, sync_offset_ns as i64 * 10);
+                            let offsettime =
+                                ((error as f64 * pgain) + (integral as f64 * igain)) as i64;
                             self.dc_system_time_ns
                                 .store(res.extra.dc_system_time, Relaxed);
-                            self.next_cycle = cycle_start + res.extra.next_cycle_wait;
+                            self.next_cycle = cycle_start + Duration::from_nanos(cycle_time_ns as u64 + offsettime as u64);
 
                             if !is_all_op {
                                 if res.all_op() {
@@ -603,12 +623,36 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                                     continue;
                                 }
                             }
-
                             match self.input_producer.input_buffer_mut() {
                                 Some(buffer) => {
                                     // We get a mutable slice to the whole buffer to make sub-slicing easier
                                     let mut current_offset = 0;
                                     for subdevice in group.iter(&maindevice) {
+                                        /*                             	  	if (subdevice.identity().product_id == EL4732_PRODUCT_ID) {
+                                                                let next_sync1_ts = u32::from_le_bytes(
+                                                                    subdevice.io_raw().inputs()[0..4].try_into().unwrap()
+                                                                );
+                                                                let dc_time_32 = (res.extra.dc_system_time & 0xFFFF_FFFF) as u32;
+                                                                let time_until_sync1 = next_sync1_ts.wrapping_sub(dc_time_32);
+                                                                let error_ns = (time_until_sync1 as i32) - sync_offset_ns as i32;
+                                                                let phase_correction_ns = error_ns / 10;
+                                                                let base_cycle = Duration::from_nanos(cycle_time_ns as u64);
+
+                                                                let duration = if phase_correction_ns >= 0 {
+                                                                    base_cycle + Duration::from_nanos(phase_correction_ns as u64)
+                                                                } else {
+                                                                    let abs_corr = phase_correction_ns.unsigned_abs() as u64;
+                                                                    if abs_corr < cycle_time_ns as u64{
+                                                                    base_cycle - Duration::from_nanos(abs_corr)
+                                                                    }else{
+                                                                       Duration::from_nanos(0)
+                                                                   }
+                                        //						    base_cycle - Duration::from_nanos(abs_corr)
+                                                                };
+                                                                                        //println!("dcref32 {} next sync1 ts {} time until sync1 {} duration until sync1 in nanos {}",dc_time_32, next_sync1_ts, time_until_sync1,duration.as_nanos());
+                                                                self.next_cycle = cycle_start + duration;
+
+                                                            }*/
                                         let len = subdevice.io_raw().inputs().len();
                                         if current_offset + len <= ETHERCAT_TX_RX_SIZE {
                                             buffer[current_offset..current_offset + len]
@@ -625,7 +669,9 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
 
                             // This gives the client side time to look at the inputs and write outputs
                             // Might be a bit too tight if running < 125us but at that point it isnt really stable anyways
-                            spinner.sleep_until(self.next_cycle - Duration::from_micros(10));
+                            spinner.sleep_until(self.next_cycle - Duration::from_nanos(10000));
+//                            println!("delta: {}, integral: {}, offsettime: {} time till next cycle {}", error, integral, offsettime,cycle_time_ns as u64 - offsettime as u64);
+                            println!("time {:?} delta: {}, integral: {}, offsettime: {} time till next cycle {}", cycle_start.elapsed() + Duration::from_nanos(10000),error, integral, offsettime,cycle_time_ns as u64 - offsettime as u64 );
                             match self.output_consumer.read() {
                                 Some(full_buffer) => {
                                     let mut current_offset = 0;
@@ -639,10 +685,10 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                                     }
                                     self.output_consumer.finish_read();
                                 }
-                                None => {}
+                                None => {
+                                    println!("NO OUTpUtSt");
+                                }
                             };
-                            // Sleep the rest of the deadline
-                            spinner.sleep_until(self.next_cycle);
                             if self.cycle.load(Relaxed) == u64::MAX {
                                 self.cycle.store(0, Relaxed);
                             } else {
@@ -650,6 +696,8 @@ impl EtherCATController<Arc<Mailbox>, Arc<Mailbox>> {
                             }
                             self.cycle_time_us
                                 .store(cycle_start.elapsed().as_micros() as u64, Relaxed);
+                            spinner.sleep_until(self.next_cycle);
+
                         }
                     });
                 }

--- a/ethercat_hal/src/devices/beckhoff_modules/el4732.rs
+++ b/ethercat_hal/src/devices/beckhoff_modules/el4732.rs
@@ -4,9 +4,8 @@ use crate::pdo::oversampling::{AnalogOutputOversample, CycleCount};
 use crate::pdo::{RxPdo, TxPdo};
 use ethercat_hal_derive::{EthercatDevice, RxPdo, TxPdo};
 
-
-const SM0_START : u16 = 0x1600;
-const SM1_START : u16 = 0x1700;
+const SM0_START: u16 = 0x1600;
+const SM1_START: u16 = 0x1700;
 
 /// EL4732 2-channel analog output device with oversampling support
 ////
@@ -52,7 +51,14 @@ impl EL4732 {
             rxpdo: EL4732RxPdo::new(oversample_factor),
             txpdo: EL4732TxPdo::default(),
             is_used: false,
-            configuration: EL4732Configuration { oversample_factor, oversampling_config: [(SM0_START, oversample_factor as u16),(SM1_START, oversample_factor as u16)].to_vec() },
+            configuration: EL4732Configuration {
+                oversample_factor,
+                oversampling_config: [
+                    (SM0_START, oversample_factor as u16),
+                    (SM1_START, oversample_factor as u16),
+                ]
+                .to_vec(),
+            },
         }
     }
 
@@ -190,14 +196,14 @@ pub enum EL4732Port {
 #[derive(Debug, Clone)]
 pub struct EL4732Configuration {
     pub oversample_factor: usize,
-    pub oversampling_config: Vec<(u16,u16)>,
+    pub oversampling_config: Vec<(u16, u16)>,
 }
 
 impl Default for EL4732Configuration {
     fn default() -> Self {
         Self {
             oversample_factor: 1,
-            oversampling_config: [(SM0_START, 1),(SM1_START, 1)].to_vec(),
+            oversampling_config: [(SM0_START, 1), (SM1_START, 1)].to_vec(),
         }
     }
 }

--- a/ethercat_hal/src/devices/beckhoff_modules/el4732.rs
+++ b/ethercat_hal/src/devices/beckhoff_modules/el4732.rs
@@ -4,9 +4,13 @@ use crate::pdo::oversampling::{AnalogOutputOversample, CycleCount};
 use crate::pdo::{RxPdo, TxPdo};
 use ethercat_hal_derive::{EthercatDevice, RxPdo, TxPdo};
 
+
+const SM0_START : u16 = 0x1600;
+const SM1_START : u16 = 0x1700;
+
 /// EL4732 2-channel analog output device with oversampling support
-///
-/// 16-bit resolution, -10V to +10V, E-Bus current: 180mA
+////
+/// 16-bit resolution, -10V to +10V
 ///
 /// `oversample_factor` must be one of: 1, 2, 3, 4, 5, 8, 10, 16, 20, 25, 32, 40, 50, 100
 /// (as defined in the EL4732 ESI DC OpModes)
@@ -14,10 +18,6 @@ use ethercat_hal_derive::{EthercatDevice, RxPdo, TxPdo};
 /// PDI layout per cycle:
 ///   SM0 (0x1000): ch1_cycle_count (u16) + [i16; N] = 2 + N*2 bytes
 ///   SM1 (0x1400): ch2_cycle_count (u16) + [i16; N] = 2 + N*2 bytes
-///
-/// DC sync is required for oversampling (AssignActivate = 0x0730).
-/// For N=1: use DcSync::Sync0
-/// For N>1: use DcSync::Sync01 { sync1_period: cycle_time / N }
 #[derive(EthercatDevice)]
 pub struct EL4732 {
     pub rxpdo: EL4732RxPdo,
@@ -52,7 +52,7 @@ impl EL4732 {
             rxpdo: EL4732RxPdo::new(oversample_factor),
             txpdo: EL4732TxPdo::default(),
             is_used: false,
-            configuration: EL4732Configuration { oversample_factor },
+            configuration: EL4732Configuration { oversample_factor, oversampling_config: [(SM0_START, oversample_factor as u16),(SM1_START, oversample_factor as u16)].to_vec() },
         }
     }
 
@@ -190,12 +190,14 @@ pub enum EL4732Port {
 #[derive(Debug, Clone)]
 pub struct EL4732Configuration {
     pub oversample_factor: usize,
+    pub oversampling_config: Vec<(u16,u16)>,
 }
 
 impl Default for EL4732Configuration {
     fn default() -> Self {
         Self {
             oversample_factor: 1,
+            oversampling_config: [(SM0_START, 1),(SM1_START, 1)].to_vec(),
         }
     }
 }

--- a/ethercat_hal/src/devices/mod.rs
+++ b/ethercat_hal/src/devices/mod.rs
@@ -8,7 +8,6 @@ use crate::TypeErasedValue;
 use crate::devices::beckhoff_modules::el1124::{EL1124, EL1124_IDENTITY_A};
 use crate::devices::beckhoff_modules::el1259::{EL1259, EL1259_IDENTITY_A};
 use crate::devices::beckhoff_modules::el9505::{EL9505, EL9505_IDENTITY_A};
-use crate::pdo::oversampling::OVERSAMPLE_FACTOR;
 
 use crate::devices::beckhoff_modules::el1008::EL1008;
 use crate::devices::beckhoff_modules::ep2339_0021::EP2339_0021_IDENTITY_A;
@@ -193,7 +192,7 @@ pub fn device_from_subdevice_identity(
         EP2339_0021_IDENTITY_A => Ok(Box::new(ep2339_0021::EP2339_0021::new())),
         MINAS_A6_IDENTITY_A => Ok(Box::new(minas_a6::MinasA6BMotor::new())),
         EL4732_IDENTITY_A | EL4732_IDENTITY_B | EL4732_IDENTITY_C => {
-            Ok(Box::new(EL4732::new_with_oversample(OVERSAMPLE_FACTOR)))
+            Ok(Box::new(EL4732::new()))
         }
         _ => Err(anyhow::anyhow!(
             "[{}::device_from_subdevice] No Driver: vendor_id: 0x{:x}, product_id: 0x{:x}, revision: 0x{:x}",
@@ -242,7 +241,7 @@ pub fn device_from_subdevice_identity_rc(
         EP2339_0021_IDENTITY_A => Ok(Rc::new(RefCell::new(ep2339_0021::EP2339_0021::new()))),
         MINAS_A6_IDENTITY_A => Ok(Rc::new(RefCell::new(minas_a6::MinasA6BMotor::new()))),
         EL4732_IDENTITY_A | EL4732_IDENTITY_B | EL4732_IDENTITY_C => Ok(Rc::new(RefCell::new(
-            el4732::EL4732::new_with_oversample(OVERSAMPLE_FACTOR),
+            el4732::EL4732::new(),
         ))),
 
         _ => Err(anyhow::anyhow!(

--- a/ethercat_hal/src/devices/mod.rs
+++ b/ethercat_hal/src/devices/mod.rs
@@ -191,9 +191,7 @@ pub fn device_from_subdevice_identity(
         }
         EP2339_0021_IDENTITY_A => Ok(Box::new(ep2339_0021::EP2339_0021::new())),
         MINAS_A6_IDENTITY_A => Ok(Box::new(minas_a6::MinasA6BMotor::new())),
-        EL4732_IDENTITY_A | EL4732_IDENTITY_B | EL4732_IDENTITY_C => {
-            Ok(Box::new(EL4732::new()))
-        }
+        EL4732_IDENTITY_A | EL4732_IDENTITY_B | EL4732_IDENTITY_C => Ok(Box::new(EL4732::new())),
         _ => Err(anyhow::anyhow!(
             "[{}::device_from_subdevice] No Driver: vendor_id: 0x{:x}, product_id: 0x{:x}, revision: 0x{:x}",
             module_path!(),
@@ -240,9 +238,9 @@ pub fn device_from_subdevice_identity_rc(
         }
         EP2339_0021_IDENTITY_A => Ok(Rc::new(RefCell::new(ep2339_0021::EP2339_0021::new()))),
         MINAS_A6_IDENTITY_A => Ok(Rc::new(RefCell::new(minas_a6::MinasA6BMotor::new()))),
-        EL4732_IDENTITY_A | EL4732_IDENTITY_B | EL4732_IDENTITY_C => Ok(Rc::new(RefCell::new(
-            el4732::EL4732::new(),
-        ))),
+        EL4732_IDENTITY_A | EL4732_IDENTITY_B | EL4732_IDENTITY_C => {
+            Ok(Rc::new(RefCell::new(el4732::EL4732::new())))
+        }
 
         _ => Err(anyhow::anyhow!(
             "[{}::device_from_subdevice] No Driver: vendor_id: 0x{:x}, product_id: 0x{:x}, revision: 0x{:x}",

--- a/ethercat_hal/src/ethercat_helpers.rs
+++ b/ethercat_hal/src/ethercat_helpers.rs
@@ -2,11 +2,9 @@
 use crate::{ChannelRequest, ChannelResponse, EtherCATThreadResponseChannel};
 #[cfg(not(feature = "mock"))]
 use std::time::Duration;
-
 use crate::{
     EtherCATState, EtherCATThreadChannel, MAX_SUBDEVICES, PDI_LEN, SdoReadRequest, SdoRequest,
-    SdoType, get_async_runtime, machine_ident_read::MachineDeviceInfo,
-    pdo::oversampling::OVERSAMPLE_FACTOR,
+    SdoType, get_async_runtime, machine_ident_read::MachineDeviceInfo
 };
 use ethercrab::{
     DcSync, EtherCrabWireRead, EtherCrabWireSized, EtherCrabWireWrite, MainDevice, SubDeviceGroup,
@@ -443,10 +441,10 @@ impl EtherCATThreadChannel {
         }
     }
 
-    pub fn configure_oversampling(&self, device_address: u16) -> Result<(), anyhow::Error> {
+    pub fn configure_oversampling(&self, device_address: u16, oversampling_settings: Vec<(u16,u16)> ) -> Result<(), anyhow::Error> {
         let (tx, rx) = std::sync::mpsc::channel::<ChannelResponse>();
         let req = ChannelRequest {
-            channel_request: crate::ChannelRequests::ConfigureOversampling(device_address.into()),
+            channel_request: crate::ChannelRequests::ConfigureOversampling(device_address.into(),oversampling_settings),
             response_channel: EtherCATThreadResponseChannel(tx),
         };
         match self.0.send(req) {
@@ -475,7 +473,7 @@ impl EtherCATThreadChannel {
             Ok(code_word) => code_word,
             // This happens when the subdevice has no mailbox
             // There is NO check in ethercrab for Mailbox presence, so we just have to pray that it has one and send a request
-            // If there is no Mailbox to write Coe Request to, then there is also no EEPROM meaning we achieved our goal in a sense
+            // If there is no Mailbox to write Coe Request to, then there is also no EEPROM writes meaning we achieved our goal in a sense
             // This is why it returns OK on an error for sdo_read
             Err(_) => return Ok(()),
         };
@@ -627,17 +625,13 @@ pub fn configure_oversampling(
     group: &mut SubDeviceGroup<MAX_SUBDEVICES, PDI_LEN>,
     maindevice: &MainDevice,
     device_address: usize,
+    oversampling_settings: &[(u16,u16)]
 ) -> Result<(), anyhow::Error> {
     let rt = get_async_runtime();
     rt.block_on(async {
         for mut subdevice in group.iter_mut(maindevice) {
             if subdevice.configured_address() == device_address as u16 {
-                // This is so dumb, Why would it need a 'static ref to TWO yes TWO u16
-                // Just copy them internally in ethercrab its a one time cost ...
-                subdevice.set_oversampling(&[
-                    (0x1600, OVERSAMPLE_FACTOR as u16),
-                    (0x1700, OVERSAMPLE_FACTOR as u16),
-                ]);
+                subdevice.set_oversampling(oversampling_settings);
                 return Ok(());
             }
         }

--- a/ethercat_hal/src/ethercat_helpers.rs
+++ b/ethercat_hal/src/ethercat_helpers.rs
@@ -1,15 +1,15 @@
 #[cfg(not(feature = "mock"))]
 use crate::{ChannelRequest, ChannelResponse, EtherCATThreadResponseChannel};
-#[cfg(not(feature = "mock"))]
-use std::time::Duration;
 use crate::{
     EtherCATState, EtherCATThreadChannel, MAX_SUBDEVICES, PDI_LEN, SdoReadRequest, SdoRequest,
-    SdoType, get_async_runtime, machine_ident_read::MachineDeviceInfo
+    SdoType, get_async_runtime, machine_ident_read::MachineDeviceInfo,
 };
 use ethercrab::{
     DcSync, EtherCrabWireRead, EtherCrabWireSized, EtherCrabWireWrite, MainDevice, SubDeviceGroup,
 };
 use std::any::TypeId;
+#[cfg(not(feature = "mock"))]
+use std::time::Duration;
 
 pub trait EthercatResponseTypedResult: Sized {
     fn from_bool(_v: bool) -> anyhow::Result<Self> {
@@ -441,10 +441,17 @@ impl EtherCATThreadChannel {
         }
     }
 
-    pub fn configure_oversampling(&self, device_address: u16, oversampling_settings: Vec<(u16,u16)> ) -> Result<(), anyhow::Error> {
+    pub fn configure_oversampling(
+        &self,
+        device_address: u16,
+        oversampling_settings: Vec<(u16, u16)>,
+    ) -> Result<(), anyhow::Error> {
         let (tx, rx) = std::sync::mpsc::channel::<ChannelResponse>();
         let req = ChannelRequest {
-            channel_request: crate::ChannelRequests::ConfigureOversampling(device_address.into(),oversampling_settings),
+            channel_request: crate::ChannelRequests::ConfigureOversampling(
+                device_address.into(),
+                oversampling_settings,
+            ),
             response_channel: EtherCATThreadResponseChannel(tx),
         };
         match self.0.send(req) {
@@ -625,7 +632,7 @@ pub fn configure_oversampling(
     group: &mut SubDeviceGroup<MAX_SUBDEVICES, PDI_LEN>,
     maindevice: &MainDevice,
     device_address: usize,
-    oversampling_settings: &[(u16,u16)]
+    oversampling_settings: &[(u16, u16)],
 ) -> Result<(), anyhow::Error> {
     let rt = get_async_runtime();
     rt.block_on(async {

--- a/ethercat_hal/src/lib.rs
+++ b/ethercat_hal/src/lib.rs
@@ -495,7 +495,7 @@ pub enum ChannelRequests {
     // Legacy code, only usable when feature legacy_code is set
     ReadMachineIdent(),
     EnableDCSync01(usize, Duration),
-    ConfigureOversampling(usize,Vec<(u16,u16)>),
+    ConfigureOversampling(usize, Vec<(u16, u16)>),
     WriteMachineIdent(Vec<MachineDeviceInfo>),
 }
 

--- a/ethercat_hal/src/lib.rs
+++ b/ethercat_hal/src/lib.rs
@@ -495,7 +495,7 @@ pub enum ChannelRequests {
     // Legacy code, only usable when feature legacy_code is set
     ReadMachineIdent(),
     EnableDCSync01(usize, Duration),
-    ConfigureOversampling(usize),
+    ConfigureOversampling(usize,Vec<(u16,u16)>),
     WriteMachineIdent(Vec<MachineDeviceInfo>),
 }
 

--- a/ethercat_hal/src/pdo/oversampling.rs
+++ b/ethercat_hal/src/pdo/oversampling.rs
@@ -1,8 +1,7 @@
 use crate::pdo::{PdoObject, RxPdoObject};
 use bitvec::{field::BitField, order::Lsb0, slice::BitSlice};
 use ethercat_hal_derive::PdoObject as PdoObjectDerive;
-
-pub const OVERSAMPLE_FACTOR: usize = 10;
+pub const OVERSAMPLE_FACTOR: usize = 4;
 
 /// PDO Object for oversampling analog output terminals (e.g. EL4732)
 ///

--- a/ethercat_hal/src/pdo/oversampling.rs
+++ b/ethercat_hal/src/pdo/oversampling.rs
@@ -1,7 +1,6 @@
 use crate::pdo::{PdoObject, RxPdoObject};
 use bitvec::{field::BitField, order::Lsb0, slice::BitSlice};
 use ethercat_hal_derive::PdoObject as PdoObjectDerive;
-pub const OVERSAMPLE_FACTOR: usize = 4;
 
 /// PDO Object for oversampling analog output terminals (e.g. EL4732)
 ///

--- a/ethercat_hal/src/pdo/oversampling.rs
+++ b/ethercat_hal/src/pdo/oversampling.rs
@@ -2,7 +2,7 @@ use crate::pdo::{PdoObject, RxPdoObject};
 use bitvec::{field::BitField, order::Lsb0, slice::BitSlice};
 use ethercat_hal_derive::PdoObject as PdoObjectDerive;
 
-pub const OVERSAMPLE_FACTOR: usize = 4;
+pub const OVERSAMPLE_FACTOR: usize = 10;
 
 /// PDO Object for oversampling analog output terminals (e.g. EL4732)
 ///

--- a/examples/el4732_minimal.rs
+++ b/examples/el4732_minimal.rs
@@ -40,7 +40,7 @@ fn main() {
     let mut dc_config = DcConfiguration::default();
     dc_config.start_delay = Duration::from_millis(100);
     dc_config.sync0_period = Duration::from_micros(SYNC0_PERIOD_US);
-    dc_config.sync0_shift = Duration::from_micros(SYNC0_PERIOD_US/2);
+    dc_config.sync0_shift = Duration::from_micros(SYNC0_PERIOD_US / 2);
     dc_config.target_dc_tick = 500;
 
     /*

--- a/examples/el4732_minimal.rs
+++ b/examples/el4732_minimal.rs
@@ -54,14 +54,13 @@ fn main() {
     let sync0_period_us: u64 = cycle_time_us / oversampling_factor as u64;
     let sync1_period_us: u64 = sync0_period_us * (oversampling_factor as u64 - 1);
 
-
     let mut el4732 = EL4732::new_with_oversample(oversampling_factor);
     let cycle_secs = cycle_time_us as f64 * 1e-6;
     let phase_step_per_slot = 2.0 * PI * sinewave_freq * cycle_secs / oversampling_factor as f64;
     let phase_step_per_cycle = 2.0 * PI * sinewave_freq * cycle_secs;
     let mut phase: f64 = 0.0;
     let mut samples_ch1 = vec![0.0f32; oversampling_factor];
-    let samples_ch2 =vec![0.0f32; oversampling_factor];
+    let samples_ch2 = vec![0.0f32; oversampling_factor];
 
     let mut dc_config = DcConfiguration::default();
     // Give some headroom for dc setup to finish

--- a/examples/el4732_minimal.rs
+++ b/examples/el4732_minimal.rs
@@ -3,21 +3,22 @@ use ethercat_hal::{
     DcConfiguration, EtherCATState, MasterConfiguration, RtOptimizationConfig,
     devices::{
         EthercatDevice, EthercatDeviceProcessing,
-        beckhoff_modules::el4732::{EL4732, EL4732_PRODUCT_ID, EL4732Port, EL4732RxPdo},
+        beckhoff_modules::el4732::{EL4732, EL4732_PRODUCT_ID, EL4732Port},
     },
     init_ethercat,
     io::analog_output::{AnalogOutputDevice, AnalogOutputOutput},
-    pdo::oversampling::OVERSAMPLE_FACTOR,
     set_current_thread_rt_priority,
 };
 use std::{env, f64::consts::PI, time::Duration};
-
+/*
 const CYCLE_TIME_US: u64 = 1000;
 const OVERSAMPLE: usize = OVERSAMPLE_FACTOR;
 const SYNC0_PERIOD_US: u64 = CYCLE_TIME_US / OVERSAMPLE as u64;
+// Sync1 Period is relative to sync0
 const SYNC1_PERIOD_US: u64 = SYNC0_PERIOD_US * (OVERSAMPLE as u64 - 1);
 const SINE_FREQ_HZ: f64 = 50.0;
 const AMPLITUDE: f64 = 0.4;
+*/
 
 fn apply_rt() {
     let id = core_affinity::CoreId { id: 2 };
@@ -25,26 +26,61 @@ fn apply_rt() {
     core_affinity::set_for_current(id);
 }
 
+const USAGE: &str = "el4732_minimal interface_name cycle_time_us oversampling_factor sine_freq amplitude\n example: ./target/release/examples/el4732_minimal enp4s0 1000 25 50.0 0.5";
+
 fn main() {
-    let interface = env::args().nth(1).expect("No interface name given");
-    let mut el4732 = EL4732::new_with_oversample(OVERSAMPLE);
+    let fail = format!("{}:\n{}", "No interface name given", USAGE);
+    let interface = env::args().nth(1).expect(&fail);
 
-    let cycle_secs = CYCLE_TIME_US as f64 * 1e-6;
-    let phase_step_per_slot = 2.0 * PI * SINE_FREQ_HZ * cycle_secs / OVERSAMPLE as f64;
-    let phase_step_per_cycle = 2.0 * PI * SINE_FREQ_HZ * cycle_secs;
+    let fail = format!("{}:\n{}", "No Cycle time (microseconds) given", USAGE);
+    let cycle_time_us: u64 = env::args()
+        .nth(2)
+        .expect(&fail)
+        .parse()
+        .expect("cycle_time_us must be a valid u64");
+
+    let fail = format!("{}:\n{}", "No Oversampling factor given", USAGE);
+    let oversampling_factor: usize = env::args()
+        .nth(3)
+        .expect(&fail)
+        .parse()
+        .expect("oversampling_factor must be a valid usize");
+
+    let fail = format!("{}:\n{}", "No Sinewave frequency given", USAGE);
+    let sinewave_freq: f64 = env::args()
+        .nth(4)
+        .expect(&fail)
+        .parse()
+        .expect("sinewave_freq must be a valid f64");
+
+    let fail = format!("{}:\n{}", "No Sinewave amplitude given", USAGE);
+    let sinewave_amplitude: f64 = env::args()
+        .nth(5)
+        .expect(&fail)
+        .parse()
+        .expect("sinewave_amplitude must be a valid f64");
+
+    let sync0_period_us: u64 = cycle_time_us / oversampling_factor as u64;
+    let sync1_period_us: u64 = sync0_period_us * (oversampling_factor as u64 - 1);
+
+
+    let mut el4732 = EL4732::new_with_oversample(oversampling_factor);
+    let cycle_secs = cycle_time_us as f64 * 1e-6;
+    let phase_step_per_slot = 2.0 * PI * sinewave_freq * cycle_secs / oversampling_factor as f64;
+    let phase_step_per_cycle = 2.0 * PI * sinewave_freq * cycle_secs;
     let mut phase: f64 = 0.0;
-
-    let mut samples_ch1 = [0.0f32; OVERSAMPLE_FACTOR];
-    let samples_ch2 = [0.0f32; OVERSAMPLE_FACTOR];
+    let mut samples_ch1 = vec![0.0f32; oversampling_factor];
+    let samples_ch2 =vec![0.0f32; oversampling_factor];
 
     let mut dc_config = DcConfiguration::default();
+    // Give some headroom for dc setup to finish
     dc_config.start_delay = Duration::from_millis(100);
-    dc_config.sync0_period = Duration::from_micros(SYNC0_PERIOD_US);
-    dc_config.sync0_shift = Duration::from_micros(SYNC0_PERIOD_US / 2);
+    dc_config.sync0_period = Duration::from_micros(sync0_period_us);
+    dc_config.sync0_shift = Duration::from_micros(sync0_period_us / 2);
     dc_config.target_dc_tick = 500;
 
     /*
-        It seems like ethercat_loop_thread_core and ethercat_io_thread_core on the same core works
+        It seems like ethercat_loop_thread_core and ethercat_io_thread_core on the same core works perfectly with io_uring(linux default)
         with SCHED_FIFO, however ethercat_loop_thread_priority needs to have a much lower priority, like 50 for example.
         This means that the io code will never get preempted, while the io only actually runs when triggered through the tx_rx_dc code
     */
@@ -58,7 +94,7 @@ fn main() {
     };
 
     let config = MasterConfiguration {
-        target_cycle_time_us: CYCLE_TIME_US as usize,
+        target_cycle_time_us: cycle_time_us as usize,
         tx_rx_config: ethercat_hal::MasterTxRxConfig::TxRxIoUring,
         dc_config,
         realtime_optimizations: Some(rt),
@@ -82,16 +118,17 @@ fn main() {
 
     for subdevice in eth_handle.try_get_subdevices_vec_sync().unwrap() {
         if subdevice.product_id == EL4732_PRODUCT_ID {
-            if OVERSAMPLE > 1 {
+            if oversampling_factor > 1 {
                 eth_control
                     .channel
-                    .configure_oversampling(subdevice.device_address)
+                    .configure_oversampling(
+                        subdevice.device_address,
+                        el4732.configuration.oversampling_config.clone(),
+                    )
                     .expect("Failed to configure oversampling");
-
-                el4732.rxpdo = EL4732RxPdo::new(OVERSAMPLE);
             }
 
-            let s1 = Duration::from_micros(SYNC1_PERIOD_US);
+            let s1 = Duration::from_micros(sync1_period_us);
             eth_control
                 .channel
                 .enable_dc_sync01(subdevice.device_address, s1)
@@ -103,9 +140,7 @@ fn main() {
         .channel
         .request_state_change(EtherCATState::Op)
         .expect("Channel was not ready");
-
     std::thread::sleep(Duration::from_millis(2000));
-
     loop {
         if eth_handle.check_all_op() {
             break;
@@ -116,7 +151,7 @@ fn main() {
 
     println!(
         "EL4732 running: {}Hz sine, oversample factor {}, cycle {}us, sync0 {}us, sync1 {}us",
-        SINE_FREQ_HZ, OVERSAMPLE, CYCLE_TIME_US, SYNC0_PERIOD_US, SYNC1_PERIOD_US
+        sinewave_freq, oversampling_factor, cycle_time_us, sync0_period_us, sync1_period_us
     );
 
     let mut last_cycle = eth_handle.get_current_cycle();
@@ -125,7 +160,7 @@ fn main() {
     loop {
         for (i, slot) in samples_ch1.iter_mut().enumerate() {
             let p = phase + phase_step_per_slot * i as f64;
-            *slot = (p.sin() * AMPLITUDE).clamp(-1.0, 1.0) as f32;
+            *slot = (p.sin() * sinewave_amplitude).clamp(-1.0, 1.0) as f32;
         }
 
         {
@@ -135,7 +170,7 @@ fn main() {
                 }
             };
 
-            if OVERSAMPLE > 1 {
+            if oversampling_factor > 1 {
                 el4732.set_output_samples(EL4732Port::AO1 as usize, &samples_ch1);
                 el4732.set_output_samples(EL4732Port::AO2 as usize, &samples_ch2);
             } else {

--- a/examples/el4732_minimal.rs
+++ b/examples/el4732_minimal.rs
@@ -10,15 +10,6 @@ use ethercat_hal::{
     set_current_thread_rt_priority,
 };
 use std::{env, f64::consts::PI, time::Duration};
-/*
-const CYCLE_TIME_US: u64 = 1000;
-const OVERSAMPLE: usize = OVERSAMPLE_FACTOR;
-const SYNC0_PERIOD_US: u64 = CYCLE_TIME_US / OVERSAMPLE as u64;
-// Sync1 Period is relative to sync0
-const SYNC1_PERIOD_US: u64 = SYNC0_PERIOD_US * (OVERSAMPLE as u64 - 1);
-const SINE_FREQ_HZ: f64 = 50.0;
-const AMPLITUDE: f64 = 0.4;
-*/
 
 fn apply_rt() {
     let id = core_affinity::CoreId { id: 2 };

--- a/examples/el4732_minimal.rs
+++ b/examples/el4732_minimal.rs
@@ -17,7 +17,7 @@ const OVERSAMPLE: usize = OVERSAMPLE_FACTOR;
 const SYNC0_PERIOD_US: u64 = CYCLE_TIME_US / OVERSAMPLE as u64;
 const SYNC1_PERIOD_US: u64 = SYNC0_PERIOD_US * (OVERSAMPLE as u64 - 1);
 const SINE_FREQ_HZ: f64 = 50.0;
-const AMPLITUDE: f64 = 0.8;
+const AMPLITUDE: f64 = 0.4;
 
 fn apply_rt() {
     let id = core_affinity::CoreId { id: 2 };

--- a/examples/el4732_minimal.rs
+++ b/examples/el4732_minimal.rs
@@ -40,7 +40,7 @@ fn main() {
     let mut dc_config = DcConfiguration::default();
     dc_config.start_delay = Duration::from_millis(100);
     dc_config.sync0_period = Duration::from_micros(SYNC0_PERIOD_US);
-    dc_config.sync0_shift = Duration::from_micros(SYNC1_PERIOD_US);
+    dc_config.sync0_shift = Duration::from_micros(SYNC0_PERIOD_US/2);
     dc_config.target_dc_tick = 500;
 
     /*


### PR DESCRIPTION
Oversampling Terminals now behave "as expected". This also currently links to a fork of ethercrab where the timings for dc_start_time are adjusted to match sync1_period and where oversampling is not &'static