### PR TITLE
Mark AnalogOutputDevice as deprecated

### DIFF
--- a/ethercat_hal/src/devices/beckhoff_modules/el2004.rs
+++ b/ethercat_hal/src/devices/beckhoff_modules/el2004.rs
@@ -31,10 +31,10 @@ impl DigitalOutputDevice for EL2004 {
     fn set_output(&mut self, port: usize, value: bool) {
         let expect_text = "All channels should be Some(_)";
         match port {
-            0 => self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into(),
-            1 => self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into(),
-            2 => self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into(),
-            3 => self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into(),
+            0 => self.rxpdo.channel1.as_mut().expect(expect_text).value = value,
+            1 => self.rxpdo.channel2.as_mut().expect(expect_text).value = value,
+            2 => self.rxpdo.channel3.as_mut().expect(expect_text).value = value,
+            3 => self.rxpdo.channel4.as_mut().expect(expect_text).value = value,
             _ => (),
         }
     }

--- a/ethercat_hal/src/devices/beckhoff_modules/el4008.rs
+++ b/ethercat_hal/src/devices/beckhoff_modules/el4008.rs
@@ -1,17 +1,21 @@
-use crate::{EtherCATThreadChannel, helpers::sdo_write_helper};
-use super::Device;
-use crate::io::analog_output::{AnalogOutputDevice, AnalogOutputState};
-use std::any::Any;
+use crate::{io::analog_output::AnalogVoltageOutputDevice, pdo::RxPdo};
+use ethercat_hal_derive::{EthercatDevice, RxPdo};
+use units::{ElectricPotential, electric_potential::volt};
 
-const OUTPUT_PDU_LEN: usize = 16;
+use crate::{
+    devices::{EthercatDeviceProcessing, NewEthercatDevice, SubDeviceIdentityTuple},
+    pdo::el40xx::AnalogOutput,
+};
 
 /// EL4008 8-channel analog output device
 ///
 /// 12-bit resolution, 0-10V
 ///
 /// load > 5kOhm
+#[derive(EthercatDevice)]
 pub struct EL4008 {
-    output_pdus: [u8; OUTPUT_PDU_LEN],
+    pub rxpdo: EL4008RxPdo,
+    pub is_used: bool,
 }
 
 impl std::fmt::Debug for EL4008 {
@@ -20,69 +24,89 @@ impl std::fmt::Debug for EL4008 {
     }
 }
 
-impl EL4008 {
-    pub fn new() -> Self {
+impl EthercatDeviceProcessing for EL4008 {}
+
+impl NewEthercatDevice for EL4008 {
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
         Self {
-            output_pdus: [0; OUTPUT_PDU_LEN],
+            rxpdo: EL4008RxPdo::default(),
+            is_used: false,
         }
     }
 }
 
-/// transform a float from 0-1 to a 12bit integer
-fn f32_to_i16(value: f32) -> i16 {
-    // Clamp the value between -1.0 and 1.0
-    let clamped_value = value.clamp(-1.0, 1.0);
-    // Scale to the 16-bit range and round
-    let scaled_value = (clamped_value * 32767.0).round();
-    // Cast to i16
-    scaled_value as i16
-}
-
-impl AnalogOutputDevice<EL4008Port> for EL4008 {
-    fn analog_output_write(&mut self, port: EL4008Port, value: f32) {
-        let pdu_index = port.to_le_pdu_index();
-        let value = f32_to_i16(value);
-        let bytes = value.to_be_bytes();
-        self.output_pdus[pdu_index + 1] = bytes[0];
-        self.output_pdus[pdu_index + 0] = bytes[1];
+impl AnalogVoltageOutputDevice for EL4008 {
+    fn get_port_count(&self) -> usize {
+        8
     }
 
-    fn analog_output_state(&self, port: EL4008Port) -> AnalogOutputState {
-        let pdu_index = port.to_le_pdu_index();
-        // turn 2 bytes into a single f32
-        let value = f32::from_le_bytes([
-            0,
-            0,
-            self.output_pdus[pdu_index + 1],
-            self.output_pdus[pdu_index],
-        ]);
-        AnalogOutputState { value }
+    fn get_minimum_output(&self) -> ElectricPotential {
+        ElectricPotential::new::<volt>(0.0)
+    }
+
+    fn get_maximum_output(&self) -> ElectricPotential {
+        ElectricPotential::new::<volt>(10.0)
+    }
+
+    fn set_output(&mut self, port: usize, value: f64) {
+        let option = match port {
+            0 => self.rxpdo.channel1.as_mut(),
+            1 => self.rxpdo.channel2.as_mut(),
+            2 => self.rxpdo.channel3.as_mut(),
+            3 => self.rxpdo.channel4.as_mut(),
+            4 => self.rxpdo.channel5.as_mut(),
+            5 => self.rxpdo.channel6.as_mut(),
+            6 => self.rxpdo.channel7.as_mut(),
+            7 => self.rxpdo.channel8.as_mut(),
+            _ => panic!("Port {} index out of range [0, 7]", port),
+        };
+
+        option
+            .expect("All channels should be Some(_)")
+            .set_f64(value);
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum EL4008Port {
-    AO1,
-    AO2,
-    AO3,
-    AO4,
-    AO5,
-    AO6,
-    AO7,
-    AO8,
+#[derive(Debug, Clone, RxPdo)]
+pub struct EL4008RxPdo {
+    #[pdo_object_index(0x1600)]
+    pub channel1: Option<AnalogOutput>,
+    #[pdo_object_index(0x1601)]
+    pub channel2: Option<AnalogOutput>,
+    #[pdo_object_index(0x1602)]
+    pub channel3: Option<AnalogOutput>,
+    #[pdo_object_index(0x1603)]
+    pub channel4: Option<AnalogOutput>,
+    #[pdo_object_index(0x1604)]
+    pub channel5: Option<AnalogOutput>,
+    #[pdo_object_index(0x1605)]
+    pub channel6: Option<AnalogOutput>,
+    #[pdo_object_index(0x1606)]
+    pub channel7: Option<AnalogOutput>,
+    #[pdo_object_index(0x1607)]
+    pub channel8: Option<AnalogOutput>,
 }
 
-impl EL4008Port {
-    pub fn to_le_pdu_index(&self) -> usize {
-        match self {
-            EL4008Port::AO1 => 0,
-            EL4008Port::AO2 => 2,
-            EL4008Port::AO3 => 4,
-            EL4008Port::AO4 => 6,
-            EL4008Port::AO5 => 8,
-            EL4008Port::AO6 => 10,
-            EL4008Port::AO7 => 12,
-            EL4008Port::AO8 => 14,
+impl Default for EL4008RxPdo {
+    fn default() -> Self {
+        Self {
+            channel1: Some(AnalogOutput::default()),
+            channel2: Some(AnalogOutput::default()),
+            channel3: Some(AnalogOutput::default()),
+            channel4: Some(AnalogOutput::default()),
+            channel5: Some(AnalogOutput::default()),
+            channel6: Some(AnalogOutput::default()),
+            channel7: Some(AnalogOutput::default()),
+            channel8: Some(AnalogOutput::default()),
         }
     }
 }
+
+pub const EL4008_VENDOR_ID: u32 = 0x2;
+pub const EL4008_PRODUCT_ID: u32 = 0x0fa83052;
+pub const EL4008_REVISION_A: u32 = 0x00140000;
+pub const EL4008_IDENTITY_A: SubDeviceIdentityTuple =
+    (EL4008_VENDOR_ID, EL4008_PRODUCT_ID, EL4008_REVISION_A);

--- a/ethercat_hal/src/devices/beckhoff_modules/mod.rs
+++ b/ethercat_hal/src/devices/beckhoff_modules/mod.rs
@@ -1,7 +1,7 @@
 pub mod ek1100;
 pub mod el1002;
 pub mod el1008;
-pub(crate) mod el1124;
+pub mod el1124;
 pub mod el1259;
 pub mod el2002;
 pub mod el2004;
@@ -17,6 +17,7 @@ pub mod el3024;
 pub mod el3062_0030;
 pub mod el3204;
 pub mod el4002;
+pub mod el4008;
 pub mod el4732;
 pub mod el5152;
 pub mod el6021;

--- a/ethercat_hal/src/devices/mod.rs
+++ b/ethercat_hal/src/devices/mod.rs
@@ -7,6 +7,7 @@ use crate::MetaSubdevice;
 use crate::TypeErasedValue;
 use crate::devices::beckhoff_modules::el1124::{EL1124, EL1124_IDENTITY_A};
 use crate::devices::beckhoff_modules::el1259::{EL1259, EL1259_IDENTITY_A};
+use crate::devices::beckhoff_modules::el4008::{EL4008, EL4008_IDENTITY_A};
 use crate::devices::beckhoff_modules::el9505::{EL9505, EL9505_IDENTITY_A};
 
 use crate::devices::beckhoff_modules::el1008::EL1008;
@@ -176,6 +177,7 @@ pub fn device_from_subdevice_identity(
         EL3024_IDENTITY_A => Ok(Box::new(el3024::EL3024::new())),
         EL3062_0030_IDENTITY_A => Ok(Box::new(el3062_0030::EL3062_0030::new())),
         EL4002_IDENTITY_A => Ok(Box::new(EL4002::new())),
+        EL4008_IDENTITY_A => Ok(Box::new(EL4008::new())),
         EL5152_IDENTITY_A => Ok(Box::new(EL5152::new())),
         EL6021_IDENTITY_A | EL6021_IDENTITY_B | EL6021_IDENTITY_C | EL6021_IDENTITY_D => {
             Ok(Box::new(el6021::EL6021::new()))
@@ -223,6 +225,7 @@ pub fn device_from_subdevice_identity_rc(
         EL3024_IDENTITY_A => Ok(Rc::new(RefCell::new(el3024::EL3024::new()))),
         EL3062_0030_IDENTITY_A => Ok(Rc::new(RefCell::new(el3062_0030::EL3062_0030::new()))),
         EL4002_IDENTITY_A => Ok(Rc::new(RefCell::new(EL4002::new()))),
+        EL4008_IDENTITY_A => Ok(Rc::new(RefCell::new(EL4008::new()))),
         EL5152_IDENTITY_A => Ok(Rc::new(RefCell::new(EL5152::new()))),
         EL6021_IDENTITY_A | EL6021_IDENTITY_B | EL6021_IDENTITY_C | EL6021_IDENTITY_D => {
             Ok(Rc::new(RefCell::new(el6021::EL6021::new())))

--- a/ethercat_hal/src/io/analog_output.rs
+++ b/ethercat_hal/src/io/analog_output.rs
@@ -17,6 +17,7 @@ pub trait AnalogVoltageOutputDevice {
 }
 
 #[derive(Debug, Clone)]
+#[deprecated(note = "Use AnalogVoltageOutputDevice instead, which supports floats directly")]
 pub struct AnalogOutputOutput(pub f32);
 
 impl From<f32> for AnalogOutputOutput {
@@ -31,6 +32,7 @@ impl From<AnalogOutputOutput> for f32 {
     }
 }
 
+#[deprecated(note = "Use AnalogVoltageOutputDevice instead")]
 pub trait AnalogOutputDevice {
     fn set_output(&mut self, port: usize, value: AnalogOutputOutput);
     fn get_port_count(&self) -> usize;

--- a/ethercat_hal/src/io/analog_output.rs
+++ b/ethercat_hal/src/io/analog_output.rs
@@ -1,3 +1,21 @@
+use units::ElectricPotential;
+
+pub trait AnalogVoltageOutputDevice {
+    /// Get the minimum voltage this device can output on a single port
+    fn get_minimum_output(&self) -> ElectricPotential;
+    /// Get the maximum voltage this device can output on a single port
+    fn get_maximum_output(&self) -> ElectricPotential;
+
+    /// Set a specific output.
+    ///
+    /// The given value must be in the interval `[-1, 1]` for devices that support negative
+    /// output values and in the interval [0, 1] for devices with only positve output values.
+    /// The value is interpolated between the minimum and maximum values of the device.
+    fn set_output(&mut self, port: usize, value: f64);
+
+    fn get_port_count(&self) -> usize;
+}
+
 #[derive(Debug, Clone)]
 pub struct AnalogOutputOutput(pub f32);
 
@@ -16,4 +34,14 @@ impl From<AnalogOutputOutput> for f32 {
 pub trait AnalogOutputDevice {
     fn set_output(&mut self, port: usize, value: AnalogOutputOutput);
     fn get_port_count(&self) -> usize;
+}
+
+impl<T: AnalogVoltageOutputDevice> AnalogOutputDevice for T {
+    fn get_port_count(&self) -> usize {
+        self.get_port_count()
+    }
+
+    fn set_output(&mut self, port: usize, value: AnalogOutputOutput) {
+        self.set_output(port, f32::from(value) as f64);
+    }
 }

--- a/ethercat_hal/src/pdo/el40xx.rs
+++ b/ethercat_hal/src/pdo/el40xx.rs
@@ -8,14 +8,30 @@ use ethercat_hal_derive::PdoObject;
 #[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 16)]
 pub struct AnalogOutput {
-    /// Output value (-32768-32767 typically corresponds to -10V to +10V)
+    /// Output value (-32768-32767 typically corresponds to -10V to +10V).
+    /// This depends on the configuration of the device and the value has to be converted to i16 with custom logic.
+    /// The 16 bit analog value is signed here but devices could interpret its value with different signing strategies.
     pub value: i16,
 }
 
 impl RxPdoObject for AnalogOutput {
     fn write(&self, bits: &mut BitSlice<u8, Lsb0>) {
-        // Write the output value to bits 0-15
         bits[0..16].store_le(self.value as u16);
+    }
+}
+
+impl AnalogOutput {
+    /// Stores the given value.
+    ///
+    /// Allowed range is [-1, 1] if the device supports outputting negative values,
+    /// As such, -1.0 outputs the minimum possible value (negative),
+    /// 0.0 outputs 0 and 1.0 outputs the maximum possible value (positive).
+    ///
+    /// Allowed range is [0, 1] if the device only supports positve values.
+    /// As such, 0.0 outputs 0 and 1.0 outputs the maximum possible value.
+    pub fn set_f64(&mut self, value: f64) {
+        let clamped_value = value.clamp(-1.0, 1.0);
+        self.value = (clamped_value * 32767.0).round() as i16;
     }
 }
 

--- a/examples/el4008_minimal.rs
+++ b/examples/el4008_minimal.rs
@@ -1,0 +1,88 @@
+use bitvec::slice::BitSlice;
+use ethercat_hal::{
+    BECKHOFF_VENDOR_ID, EtherCATState,
+    devices::{
+        EthercatDevice, NewEthercatDevice,
+        beckhoff_modules::el4008::{EL4008, EL4008_PRODUCT_ID},
+    },
+    init_ethercat,
+    io::analog_output::AnalogVoltageOutputDevice,
+};
+use std::{env, time::Duration};
+
+/// Minimal example for the EL4008 digital output (0V to 10V).
+///
+/// It create a stepfunction with 16 individual values.
+/// Best viewed with an oscilloscope.
+fn main() {
+    let interface = env::args().nth(1).expect("No Interface-name given");
+    let eth_control = init_ethercat(&interface, None);
+    let mut eth_handle = eth_control.app_handle;
+
+    eth_control
+        .channel
+        .request_state_change(EtherCATState::PreOp)
+        .expect("Channel was not ready");
+
+    // Wait for state change
+    loop {
+        let val = eth_handle.get_state();
+        match val {
+            EtherCATState::PreOp => break,
+            _ => std::thread::sleep(Duration::from_millis(10)),
+        }
+    }
+
+    println!("preop");
+
+    eth_control
+        .channel
+        .request_state_change(EtherCATState::Op)
+        .expect("Failed to go into OP");
+
+    // Wait for state change
+    loop {
+        match eth_handle.get_state() {
+            EtherCATState::Op => break,
+            _ => std::thread::sleep(Duration::from_millis(10)),
+        }
+    }
+
+    println!("op");
+
+    let subdevices = eth_handle.try_get_subdevices_vec_sync().unwrap();
+
+    // This variable "knows" how to format the Rx PDOs for the EL4008
+    let mut el4008: EL4008 = EL4008::new();
+    for iter in 0.. {
+        // Tick our application.
+        // Here, we just set output.
+        for port in 0..el4008.get_port_count() {
+            let jumps = 16;
+            let value = (iter % jumps) as f64 / (jumps as f64);
+            el4008.set_output(port, value);
+        }
+
+        // We ONLY have outputs so no need to call get_inputs
+        if let Some(outputs) = eth_handle.write_outputs() {
+            for subdevice in &subdevices {
+                // Loop over the subdevices until the EL4008 is found
+                if subdevice.vendor == BECKHOFF_VENDOR_ID
+                    && subdevice.product_id == EL4008_PRODUCT_ID
+                {
+                    // Get the part of the Rx PDO that is used by the EL4008
+                    let subdevice_outputs = &mut outputs[subdevice.start_rx..subdevice.end_rx];
+
+                    // Create the actual Rx PDO and put it into the output
+                    el4008
+                        .output(BitSlice::from_slice_mut(subdevice_outputs))
+                        .expect("Failed to write Rx PDO");
+                }
+            }
+        }
+
+        // Send the output through the EtherCAT terminals
+        eth_handle.send_outputs();
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}


### PR DESCRIPTION
This is a first approach to remove the illogical mix between voltage and current devices.
In fact, the mixture for analog inputs is even worst. A device will control output voltage and current at time, but we have a complete mix (https://github.com/qitechgmbh/qitech_lib/blob/main/ethercat_hal/src/io/analog_input/physical.rs#L4). In the future, we would like to split the trait into two: One for controlling voltage and one for controlling current. By then, it should also be possible to passt `ElectricCurrent` directly, and don't have a useless wrapper that does not add any semantic information towards modeling the actual problem statement.